### PR TITLE
chore: add git and GitHub CLI permissions to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,15 +11,11 @@
       "Edit(./README.md)",
       "Edit(./e2e/**)",
       "Edit(./.claude/**)",
-      "Edit(./CLAUDE.md)"
-    ],
-    "ask": [
-      "Edit(./next.config.js)",
-      "Edit(./next.config.mjs)",
-      "Edit(./tailwind.config.js)",
-      "Edit(./tailwind.config.ts)",
-      "Edit(./tsconfig.json)",
-      "Edit(./package.json)"
+      "Edit(./CLAUDE.md)",
+      "Bash(gh pr:*)",
+      "Bash(git fetch:*)",
+      "Bash(git stash:*)",
+      "Bash(git add:*)"
     ],
     "deny": [
       "Edit(.env)",
@@ -29,6 +25,14 @@
       "Edit(.git/**)",
       "Edit(node_modules/**)",
       "Edit(.next/**)"
+    ],
+    "ask": [
+      "Edit(./next.config.js)",
+      "Edit(./next.config.mjs)",
+      "Edit(./tailwind.config.js)",
+      "Edit(./tailwind.config.ts)",
+      "Edit(./tsconfig.json)",
+      "Edit(./package.json)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added auto-approval for common git operations (`git fetch`, `git stash`, `git add`)
- Added auto-approval for GitHub CLI PR operations (`gh pr:*`)
- Reorganized settings.json structure (moved allow rules before ask rules for consistency)

## Test plan
- [x] Verify settings.json is valid JSON
- [x] Confirm permissions are in the correct allow list
- [ ] Test that git and gh commands no longer require manual approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)