### PR TITLE
refactor: replace deprecated StyledSelect with StyledDropdown in CandidateFilters

### DIFF
--- a/app/admin/maintenance/candidates/components/CandidateFilters.tsx
+++ b/app/admin/maintenance/candidates/components/CandidateFilters.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReviewStatus, MediaType } from "@/lib/validations/maintenance"
-import { StyledSelect } from "@/components/ui/styled-select"
+import { StyledDropdown } from "@/components/ui/styled-dropdown"
 
 interface CandidateFiltersProps {
   reviewStatusFilter: ReviewStatus | "ALL"
@@ -20,7 +20,7 @@ export function CandidateFilters({
     <div className="flex gap-3 flex-wrap">
       <div>
         <label className="text-xs text-slate-400 mb-1 block">Review Status</label>
-        <StyledSelect
+        <StyledDropdown
           value={reviewStatusFilter}
           onChange={(value) => onReviewStatusChange(value as ReviewStatus | "ALL")}
           options={[
@@ -29,13 +29,14 @@ export function CandidateFilters({
             { value: "APPROVED", label: "Approved" },
             { value: "REJECTED", label: "Rejected" },
           ]}
+          size="md"
           data-testid="review-status-filter"
         />
       </div>
 
       <div>
         <label className="text-xs text-slate-400 mb-1 block">Media Type</label>
-        <StyledSelect
+        <StyledDropdown
           value={mediaTypeFilter}
           onChange={(value) => onMediaTypeChange(value as MediaType | "ALL")}
           options={[
@@ -44,6 +45,7 @@ export function CandidateFilters({
             { value: "TV_SERIES", label: "TV Series" },
             { value: "EPISODE", label: "Episode" },
           ]}
+          size="md"
           data-testid="media-type-filter"
         />
       </div>


### PR DESCRIPTION
## Summary

Resolves #55

This PR replaces the deprecated `StyledSelect` component with the recommended `StyledDropdown` component in `CandidateFilters.tsx`, addressing the deprecation notice and ensuring consistent styling across the project.

## Changes

### Updated Component
- **`app/admin/maintenance/candidates/components/CandidateFilters.tsx`**
  - Changed import from `StyledSelect` to `StyledDropdown`
  - Converted both filter dropdowns (Review Status and Media Type) to use `StyledDropdown`
  - Added `size="md"` prop to maintain consistent sizing with project standards
  - Preserved all existing functionality including:
    - Change handlers
    - Test IDs (`review-status-filter`, `media-type-filter`)
    - Option arrays and values

## Deprecation Context

From `components/ui/styled-select.tsx:4-6`:
```typescript
/**
 * @deprecated This component is deprecated. Use StyledDropdown instead for consistent styling across the project.
 * StyledDropdown provides the same functionality with better visual consistency and supports optgroups.
 */
```

## Benefits

- ✅ Removes usage of deprecated component
- ✅ Ensures consistent styling with `StyledDropdown` used elsewhere
- ✅ Maintains all existing functionality
- ✅ No breaking changes - API is compatible
- ✅ Better visual consistency across admin UI

## Testing

- ✅ All existing tests pass
- ✅ Build succeeds with no TypeScript errors
- ✅ No ESLint errors
- ✅ Functionality verified - both dropdowns work as expected

## Before/After

**Before:**
```typescript
import { StyledSelect } from "@/components/ui/styled-select"

<StyledSelect
  value={reviewStatusFilter}
  onChange={...}
  options={[...]}
  data-testid="review-status-filter"
/>
```

**After:**
```typescript
import { StyledDropdown } from "@/components/ui/styled-dropdown"

<StyledDropdown
  value={reviewStatusFilter}
  onChange={...}
  options={[...]}
  size="md"
  data-testid="review-status-filter"
/>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)