### PR TITLE
Add database index for MaintenanceCandidate queries

### DIFF
--- a/prisma/migrations/20251128040847_add_maintenance_candidate_media_type_plex_rating_key_index/migration.sql
+++ b/prisma/migrations/20251128040847_add_maintenance_candidate_media_type_plex_rating_key_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "MaintenanceCandidate_mediaType_plexRatingKey_idx" ON "MaintenanceCandidate"("mediaType", "plexRatingKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -467,6 +467,7 @@ model MaintenanceCandidate {
   @@index([scanId, reviewStatus])
   @@index([mediaType, reviewStatus])
   @@index([reviewStatus, flaggedAt])
+  @@index([mediaType, plexRatingKey])
   @@unique([scanId, plexRatingKey])
 }
 


### PR DESCRIPTION
## Summary

- Add composite index on `[mediaType, plexRatingKey]` to `MaintenanceCandidate` model
- Improves query performance when filtering candidates by media type and Plex rating key
- Prevents full table scans on large candidate sets as data grows

## Changes

- **Schema Update**: Added `@@index([mediaType, plexRatingKey])` to `MaintenanceCandidate` model (prisma/schema.prisma:470)
- **Migration**: Created migration `20251128040847_add_maintenance_candidate_media_type_plex_rating_key_index`

## Testing

- ✅ Build passes with no errors
- ✅ All unit tests pass
- ✅ Migration successfully applied to development database
- ✅ Index created: `MaintenanceCandidate_mediaType_plexRatingKey_idx`

## Performance Impact

This index optimizes queries like:
```typescript
const candidates = await prisma.maintenanceCandidate.findMany({
  where: {
    mediaType: 'MOVIE',
    plexRatingKey: 'some-key',
  },
})
```

Resolves #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)