### PR TITLE
fix: only upload .next/ directory to prevent overwriting source files in public/ (#84)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: build-output
-          path: |
-            .next/
-            public/
+          path: .next/
           retention-days: 1
 
   e2e:


### PR DESCRIPTION
## Summary
Fixes #84 - Prevents artifact download from overwriting source files in the `public/` directory.

## Problem
The artifact upload/download workflow introduced in PR #82 included both `.next/` and `public/` directories. Since the E2E job checks out code first and then downloads artifacts, this would overwrite any source files in `public/` (e.g., `icon.svg`) with the artifact contents, potentially causing data loss.

## Solution
- Updated artifact upload to only include `.next/` directory
- The `public/` directory now remains untouched from source control during the E2E job
- No changes needed to download step - it will only download what was uploaded

## Changes
- Modified `.github/workflows/build.yml:84` to upload only `.next/` instead of both `.next/` and `public/`

## Impact
- ✅ Prevents source file loss in `public/` directory
- ✅ E2E tests still work correctly (only need `.next/` for running)
- ✅ No performance impact - actually slightly faster due to smaller artifact

## Test Plan
- [x] Verified YAML syntax is valid
- [x] Linter passes
- [x] Confirmed `public/icon.svg` exists as source file that needs protection
- [ ] Monitor CI run to verify E2E tests work with artifact containing only `.next/`

## Related
- Fixes #84
- Follow-up to PR #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)