### PR TITLE
refactor: remove redundant new Date() wrapper in formatDate

### DIFF
--- a/lib/utils/formatters.ts
+++ b/lib/utils/formatters.ts
@@ -27,7 +27,7 @@ export function formatFileSize(bytes: bigint | number | null): string {
  */
 export function formatDate(date: Date | null): string {
   if (!date) return 'Never'
-  return new Date(date).toLocaleDateString()
+  return date.toLocaleDateString()
 }
 
 /**


### PR DESCRIPTION
## Summary

- Removed unnecessary `new Date()` wrapper in `formatDate` utility function
- The function signature accepts `Date | null`, so the date parameter is already a `Date` object - wrapping it again was redundant

## Test plan

- [x] Existing unit tests pass (16/16 tests passing)
- [x] Lint checks pass
- [x] Build succeeds

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)