### PR TITLE
chore(deps): remove unnecessary @types/uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/qs": "^6.14.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
-        "@types/uuid": "^10.0.0",
         "autoprefixer": "^10.4.0",
         "eslint": "^9.0.0",
         "eslint-config-next": "^16.0.3",
@@ -3333,13 +3332,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/qs": "^6.14.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.0.3",


### PR DESCRIPTION
## Summary
- Remove `@types/uuid` from devDependencies as it's no longer needed

## Details

The `@types/uuid` package is unnecessary because:
- The `uuid` package (v8+) includes its own TypeScript definitions
- This project doesn't directly import from `uuid` anywhere
- The `@types/uuid@11.0.0` version is deprecated (it's just a stub package)

### Background
Dependabot PR #13 attempted to upgrade `@types/uuid` from v10 to v11, but:
- v11.0.0 is a deprecated stub package that just re-exports types from `uuid`
- The upgrade broke the build with: `Cannot find type definition file for 'uuid'`
- Since this project doesn't use `uuid` directly, the correct fix is to remove the dependency entirely

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] No code changes needed (package was unused)

Closes #13 (supersedes the dependabot upgrade PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)