### PR TITLE
feat: add title case formatting to getMediaTypeLabel fallback

### DIFF
--- a/__tests__/lib/formatters.test.ts
+++ b/__tests__/lib/formatters.test.ts
@@ -96,18 +96,18 @@ describe('getMediaTypeLabel', () => {
     expect(getMediaTypeLabel('EPISODE')).toBe('Episode')
   })
 
-  it('should replace underscores with spaces for unknown types', () => {
-    expect(getMediaTypeLabel('UNKNOWN_TYPE')).toBe('UNKNOWN TYPE')
-    expect(getMediaTypeLabel('MUSIC_VIDEO')).toBe('MUSIC VIDEO')
-    expect(getMediaTypeLabel('SOME_OTHER_TYPE')).toBe('SOME OTHER TYPE')
+  it('should convert unknown types to title case with underscores replaced by spaces', () => {
+    expect(getMediaTypeLabel('UNKNOWN_TYPE')).toBe('Unknown Type')
+    expect(getMediaTypeLabel('MUSIC_VIDEO')).toBe('Music Video')
+    expect(getMediaTypeLabel('SOME_OTHER_TYPE')).toBe('Some Other Type')
   })
 
-  it('should return type as-is if no underscores and not in map', () => {
-    expect(getMediaTypeLabel('CUSTOM')).toBe('CUSTOM')
-    expect(getMediaTypeLabel('OTHER')).toBe('OTHER')
+  it('should convert unknown types to title case even without underscores', () => {
+    expect(getMediaTypeLabel('CUSTOM')).toBe('Custom')
+    expect(getMediaTypeLabel('OTHER')).toBe('Other')
   })
 
-  it('should handle multiple underscores', () => {
-    expect(getMediaTypeLabel('VERY_LONG_TYPE_NAME')).toBe('VERY LONG TYPE NAME')
+  it('should handle multiple underscores and convert to title case', () => {
+    expect(getMediaTypeLabel('VERY_LONG_TYPE_NAME')).toBe('Very Long Type Name')
   })
 })

--- a/lib/utils/formatters.ts
+++ b/lib/utils/formatters.ts
@@ -41,6 +41,11 @@ export function getMediaTypeLabel(mediaType: string): string {
     'EPISODE': 'Episode',
   }
 
-  // Fallback: replace underscores with spaces for any unlabeled types
-  return labels[mediaType] || mediaType.replace(/_/g, ' ')
+  if (labels[mediaType]) return labels[mediaType]
+
+  // Fallback: convert to title case for consistency with known types
+  return mediaType
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (char) => char.toUpperCase())
 }


### PR DESCRIPTION
## Summary

Implements #72 - Enhanced the `getMediaTypeLabel` function to convert unknown media types to title case for consistency with known type labels.

## Changes

- **Updated `lib/utils/formatters.ts`**: Modified the fallback logic to convert unknown media types to title case
  - Replaces underscores with spaces
  - Converts to lowercase
  - Capitalizes first letter of each word
- **Updated `__tests__/lib/formatters.test.ts`**: Updated test cases to expect title case output

## Example Output

- Before: `"MUSIC_VIDEO"` → `"MUSIC VIDEO"` (ALL CAPS)
- After: `"MUSIC_VIDEO"` → `"Music Video"` (title case)

## Testing

- ✅ All unit tests pass (19/19)
- ✅ Build completes successfully with no type errors
- ✅ Linter passes with no issues

## Rationale

This is a UX improvement for consistency. Known media types return title-cased labels ("Movie", "TV Series", "Episode"), so unknown types should follow the same pattern instead of appearing in ALL CAPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)