### PR TITLE
test: add unit tests for extracted maintenance components

### DIFF
--- a/app/admin/maintenance/rules/components/__tests__/RuleActions.test.tsx
+++ b/app/admin/maintenance/rules/components/__tests__/RuleActions.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import { RuleActions } from '../RuleActions'
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  )
+})
+
+describe('RuleActions', () => {
+  describe('Basic Rendering', () => {
+    it('should render create rule link', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link', { name: /Create Rule/i })
+      expect(link).toBeInTheDocument()
+    })
+
+    it('should link to new rule page', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link')
+      expect(link).toHaveAttribute('href', '/admin/maintenance/rules/new')
+    })
+
+    it('should display "Create Rule" text', () => {
+      render(<RuleActions />)
+
+      expect(screen.getByText('Create Rule')).toBeInTheDocument()
+    })
+  })
+
+  describe('Styling', () => {
+    it('should have proper button styling classes', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link')
+      expect(link).toHaveClass('px-4', 'py-2')
+      expect(link).toHaveClass('bg-cyan-600')
+      expect(link).toHaveClass('hover:bg-cyan-500')
+      expect(link).toHaveClass('text-white')
+      expect(link).toHaveClass('rounded-lg')
+      expect(link).toHaveClass('font-medium')
+    })
+
+    it('should have flex layout with gap for icon', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link')
+      expect(link).toHaveClass('flex', 'items-center', 'gap-2')
+    })
+
+    it('should have transition effect', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link')
+      expect(link).toHaveClass('transition-colors')
+    })
+  })
+
+  describe('Icon', () => {
+    it('should render plus icon', () => {
+      const { container } = render(<RuleActions />)
+
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('should have proper icon size', () => {
+      const { container } = render(<RuleActions />)
+
+      const svg = container.querySelector('svg')
+      expect(svg).toHaveClass('w-5', 'h-5')
+    })
+
+    it('should have plus icon path', () => {
+      const { container } = render(<RuleActions />)
+
+      const path = container.querySelector('path')
+      expect(path).toBeInTheDocument()
+      expect(path).toHaveAttribute('d', 'M12 4v16m8-8H4')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should be keyboard accessible as a link', () => {
+      render(<RuleActions />)
+
+      const link = screen.getByRole('link')
+      expect(link).toBeInTheDocument()
+      // Links are inherently keyboard accessible
+    })
+  })
+})

--- a/app/admin/maintenance/rules/components/__tests__/RuleList.test.tsx
+++ b/app/admin/maintenance/rules/components/__tests__/RuleList.test.tsx
@@ -1,0 +1,358 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RuleList } from '../RuleList'
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+})
+
+// Mock formatters
+jest.mock('@/lib/utils/formatters', () => ({
+  getMediaTypeLabel: (type: string) => {
+    switch (type) {
+      case 'MOVIE':
+        return 'Movie'
+      case 'TV_SERIES':
+        return 'TV Series'
+      case 'EPISODE':
+        return 'Episode'
+      default:
+        return type
+    }
+  },
+}))
+
+type MaintenanceRule = {
+  id: string
+  name: string
+  description: string | null
+  enabled: boolean
+  mediaType: string
+  actionType: string
+  schedule: string | null
+  createdAt: Date
+  scans: Array<{
+    id: string
+    status: string
+    itemsScanned: number
+    itemsFlagged: number
+    completedAt: Date | null
+  }>
+  _count: {
+    scans: number
+  }
+}
+
+describe('RuleList', () => {
+  const mockRule: MaintenanceRule = {
+    id: 'rule-1',
+    name: 'Old Unwatched Movies',
+    description: 'Clean up movies not watched in 6 months',
+    enabled: true,
+    mediaType: 'MOVIE',
+    actionType: 'FLAG_FOR_REVIEW',
+    schedule: '0 0 * * 0',
+    createdAt: new Date('2024-01-01'),
+    scans: [
+      {
+        id: 'scan-1',
+        status: 'COMPLETED',
+        itemsScanned: 100,
+        itemsFlagged: 15,
+        completedAt: new Date('2024-11-15'),
+      },
+    ],
+    _count: {
+      scans: 5,
+    },
+  }
+
+  const defaultProps = {
+    rules: [mockRule],
+    onToggle: jest.fn(),
+    onManualScan: jest.fn(),
+    onDeleteClick: jest.fn(),
+    isTogglePending: false,
+    isScanPending: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Empty State', () => {
+    it('should display empty state when no rules', () => {
+      render(<RuleList {...defaultProps} rules={[]} />)
+
+      expect(screen.getByText('No rules yet')).toBeInTheDocument()
+      expect(
+        screen.getByText('Create a maintenance rule to start automating library cleanup.')
+      ).toBeInTheDocument()
+    })
+
+    it('should display create first rule link in empty state', () => {
+      render(<RuleList {...defaultProps} rules={[]} />)
+
+      const createLink = screen.getByRole('link', { name: /Create First Rule/i })
+      expect(createLink).toBeInTheDocument()
+      expect(createLink).toHaveAttribute('href', '/admin/maintenance/rules/new')
+    })
+  })
+
+  describe('Rule Display', () => {
+    it('should render rule with all details', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('Old Unwatched Movies')).toBeInTheDocument()
+      expect(screen.getByText('Clean up movies not watched in 6 months')).toBeInTheDocument()
+      expect(screen.getByText('Movie')).toBeInTheDocument()
+      expect(screen.getByText('Flag for Review')).toBeInTheDocument()
+    })
+
+    it('should display rule without description', () => {
+      const ruleWithoutDescription = { ...mockRule, description: null }
+      render(<RuleList {...defaultProps} rules={[ruleWithoutDescription]} />)
+
+      expect(screen.getByText('Old Unwatched Movies')).toBeInTheDocument()
+      expect(screen.queryByText('Clean up movies not watched in 6 months')).not.toBeInTheDocument()
+    })
+
+    it('should display enabled status correctly', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+
+    it('should display disabled status correctly', () => {
+      const disabledRule = { ...mockRule, enabled: false }
+      render(<RuleList {...defaultProps} rules={[disabledRule]} />)
+
+      expect(screen.getByText('Disabled')).toBeInTheDocument()
+    })
+
+    it('should display scan count', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('5 total')).toBeInTheDocument()
+    })
+
+    it('should display flagged count from last scan', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('(15 flagged)')).toBeInTheDocument()
+    })
+
+    it('should not display flagged count when zero', () => {
+      const ruleWithNoFlagged = {
+        ...mockRule,
+        scans: [{ ...mockRule.scans[0], itemsFlagged: 0 }],
+      }
+      render(<RuleList {...defaultProps} rules={[ruleWithNoFlagged]} />)
+
+      expect(screen.queryByText(/flagged/)).not.toBeInTheDocument()
+    })
+
+    it('should display last run date', () => {
+      render(<RuleList {...defaultProps} />)
+
+      // Date formatted as localized date string
+      const expectedDate = new Date('2024-11-15').toLocaleDateString()
+      expect(screen.getByText(expectedDate)).toBeInTheDocument()
+    })
+
+    it('should display "Never" when no scans completed', () => {
+      const ruleWithNoScans = { ...mockRule, scans: [] }
+      render(<RuleList {...defaultProps} rules={[ruleWithNoScans]} />)
+
+      expect(screen.getByText('Never')).toBeInTheDocument()
+    })
+  })
+
+  describe('Action Types', () => {
+    it('should display Flag for Review action type', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('Flag for Review')).toBeInTheDocument()
+    })
+
+    it('should display Auto Delete action type', () => {
+      const autoDeleteRule = { ...mockRule, actionType: 'AUTO_DELETE' }
+      render(<RuleList {...defaultProps} rules={[autoDeleteRule]} />)
+
+      expect(screen.getByText('Auto Delete')).toBeInTheDocument()
+    })
+
+    it('should style Auto Delete action type in red', () => {
+      const autoDeleteRule = { ...mockRule, actionType: 'AUTO_DELETE' }
+      render(<RuleList {...defaultProps} rules={[autoDeleteRule]} />)
+
+      const badge = screen.getByText('Auto Delete')
+      expect(badge).toHaveClass('bg-red-400/10', 'text-red-400')
+    })
+
+    it('should style Flag for Review in yellow', () => {
+      render(<RuleList {...defaultProps} />)
+
+      const badge = screen.getByText('Flag for Review')
+      expect(badge).toHaveClass('bg-yellow-400/10', 'text-yellow-400')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onToggle when status button is clicked', async () => {
+      const user = userEvent.setup()
+      const onToggle = jest.fn()
+
+      render(<RuleList {...defaultProps} onToggle={onToggle} />)
+
+      await user.click(screen.getByTestId('toggle-rule-rule-1'))
+
+      expect(onToggle).toHaveBeenCalledWith('rule-1', true)
+    })
+
+    it('should call onManualScan when scan button is clicked', async () => {
+      const user = userEvent.setup()
+      const onManualScan = jest.fn()
+
+      render(<RuleList {...defaultProps} onManualScan={onManualScan} />)
+
+      await user.click(screen.getByTestId('scan-rule-rule-1'))
+
+      expect(onManualScan).toHaveBeenCalledWith('rule-1')
+    })
+
+    it('should call onDeleteClick when delete button is clicked', async () => {
+      const user = userEvent.setup()
+      const onDeleteClick = jest.fn()
+
+      render(<RuleList {...defaultProps} onDeleteClick={onDeleteClick} />)
+
+      await user.click(screen.getByTestId('delete-rule-rule-1'))
+
+      expect(onDeleteClick).toHaveBeenCalledWith('rule-1')
+    })
+
+    it('should link to edit page', () => {
+      render(<RuleList {...defaultProps} />)
+
+      const editLink = screen.getByTestId('edit-rule-rule-1')
+      expect(editLink).toHaveAttribute('href', '/admin/maintenance/rules/rule-1/edit')
+    })
+  })
+
+  describe('Disabled States', () => {
+    it('should disable toggle button when isTogglePending is true', () => {
+      render(<RuleList {...defaultProps} isTogglePending={true} />)
+
+      expect(screen.getByTestId('toggle-rule-rule-1')).toBeDisabled()
+    })
+
+    it('should disable scan button when isScanPending is true', () => {
+      render(<RuleList {...defaultProps} isScanPending={true} />)
+
+      expect(screen.getByTestId('scan-rule-rule-1')).toBeDisabled()
+    })
+
+    it('should disable scan button when rule is disabled', () => {
+      const disabledRule = { ...mockRule, enabled: false }
+      render(<RuleList {...defaultProps} rules={[disabledRule]} />)
+
+      expect(screen.getByTestId('scan-rule-rule-1')).toBeDisabled()
+    })
+
+    it('should enable scan button when rule is enabled and not pending', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByTestId('scan-rule-rule-1')).not.toBeDisabled()
+    })
+  })
+
+  describe('Multiple Rules', () => {
+    it('should render multiple rules', () => {
+      const rules = [
+        mockRule,
+        { ...mockRule, id: 'rule-2', name: 'TV Series Cleanup', mediaType: 'TV_SERIES' },
+        { ...mockRule, id: 'rule-3', name: 'Episode Cleanup', mediaType: 'EPISODE' },
+      ]
+
+      render(<RuleList {...defaultProps} rules={rules} />)
+
+      expect(screen.getByText('Old Unwatched Movies')).toBeInTheDocument()
+      expect(screen.getByText('TV Series Cleanup')).toBeInTheDocument()
+      expect(screen.getByText('Episode Cleanup')).toBeInTheDocument()
+    })
+
+    it('should have correct test IDs for multiple rules', () => {
+      const rules = [
+        mockRule,
+        { ...mockRule, id: 'rule-2', name: 'Second Rule' },
+      ]
+
+      render(<RuleList {...defaultProps} rules={rules} />)
+
+      expect(screen.getByTestId('rule-row-rule-1')).toBeInTheDocument()
+      expect(screen.getByTestId('rule-row-rule-2')).toBeInTheDocument()
+    })
+  })
+
+  describe('Media Types', () => {
+    it('should display Movie media type', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('Movie')).toBeInTheDocument()
+    })
+
+    it('should display TV Series media type', () => {
+      const tvRule = { ...mockRule, mediaType: 'TV_SERIES' }
+      render(<RuleList {...defaultProps} rules={[tvRule]} />)
+
+      expect(screen.getByText('TV Series')).toBeInTheDocument()
+    })
+
+    it('should display Episode media type', () => {
+      const episodeRule = { ...mockRule, mediaType: 'EPISODE' }
+      render(<RuleList {...defaultProps} rules={[episodeRule]} />)
+
+      expect(screen.getByText('Episode')).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have data-testid attributes for testing', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByTestId('rule-row-rule-1')).toBeInTheDocument()
+      expect(screen.getByTestId('toggle-rule-rule-1')).toBeInTheDocument()
+      expect(screen.getByTestId('scan-rule-rule-1')).toBeInTheDocument()
+      expect(screen.getByTestId('edit-rule-rule-1')).toBeInTheDocument()
+      expect(screen.getByTestId('delete-rule-rule-1')).toBeInTheDocument()
+    })
+
+    it('should have title attributes on action buttons', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByTestId('scan-rule-rule-1')).toHaveAttribute('title', 'Run Scan')
+      expect(screen.getByTestId('edit-rule-rule-1')).toHaveAttribute('title', 'Edit')
+      expect(screen.getByTestId('delete-rule-rule-1')).toHaveAttribute('title', 'Delete')
+    })
+  })
+
+  describe('Table Headers', () => {
+    it('should display all table headers', () => {
+      render(<RuleList {...defaultProps} />)
+
+      expect(screen.getByText('Rule Name')).toBeInTheDocument()
+      expect(screen.getByText('Media Type')).toBeInTheDocument()
+      expect(screen.getByText('Action')).toBeInTheDocument()
+      expect(screen.getByText('Status')).toBeInTheDocument()
+      expect(screen.getByText('Scans')).toBeInTheDocument()
+      expect(screen.getByText('Last Run')).toBeInTheDocument()
+      expect(screen.getByText('Actions')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/BooleanToggle.test.tsx
+++ b/components/maintenance/inputs/__tests__/BooleanToggle.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BooleanToggle } from '../BooleanToggle'
+import type { Condition } from '@/lib/validations/maintenance'
+
+// Mock Button component
+jest.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    variant,
+    'data-testid': dataTestId,
+  }: {
+    children: React.ReactNode
+    onClick: () => void
+    variant?: string
+    'data-testid'?: string
+  }) => (
+    <button onClick={onClick} data-variant={variant} data-testid={dataTestId}>
+      {children}
+    </button>
+  ),
+}))
+
+describe('BooleanToggle', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: boolean | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'neverWatched',
+    operator: 'equals',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render True and False buttons', () => {
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('boolean-toggle-true')).toBeInTheDocument()
+      expect(screen.getByTestId('boolean-toggle-false')).toBeInTheDocument()
+      expect(screen.getByText('True')).toBeInTheDocument()
+      expect(screen.getByText('False')).toBeInTheDocument()
+    })
+
+    it('should have type="button" on buttons', () => {
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      // The mock doesn't set type, but we can verify buttons render
+      expect(screen.getByTestId('boolean-toggle-true')).toBeInTheDocument()
+      expect(screen.getByTestId('boolean-toggle-false')).toBeInTheDocument()
+    })
+  })
+
+  describe('Value Display', () => {
+    it('should show success variant for True button when value is true', () => {
+      const condition = createCondition(true)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const trueButton = screen.getByTestId('boolean-toggle-true')
+      expect(trueButton).toHaveAttribute('data-variant', 'success')
+    })
+
+    it('should show secondary variant for False button when value is true', () => {
+      const condition = createCondition(true)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const falseButton = screen.getByTestId('boolean-toggle-false')
+      expect(falseButton).toHaveAttribute('data-variant', 'secondary')
+    })
+
+    it('should show danger variant for False button when value is false', () => {
+      const condition = createCondition(false)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const falseButton = screen.getByTestId('boolean-toggle-false')
+      expect(falseButton).toHaveAttribute('data-variant', 'danger')
+    })
+
+    it('should show secondary variant for True button when value is false', () => {
+      const condition = createCondition(false)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const trueButton = screen.getByTestId('boolean-toggle-true')
+      expect(trueButton).toHaveAttribute('data-variant', 'secondary')
+    })
+
+    it('should show secondary variant for both buttons when value is null', () => {
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const trueButton = screen.getByTestId('boolean-toggle-true')
+      const falseButton = screen.getByTestId('boolean-toggle-false')
+
+      expect(trueButton).toHaveAttribute('data-variant', 'secondary')
+      expect(falseButton).toHaveAttribute('data-variant', 'secondary')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange with true when True button is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-true'))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: true,
+        })
+      )
+    })
+
+    it('should call onChange with false when False button is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-false'))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: false,
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when clicking True', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-true'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'neverWatched',
+        operator: 'equals',
+        value: true,
+      })
+    })
+
+    it('should preserve condition field and operator when clicking False', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-false'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'neverWatched',
+        operator: 'equals',
+        value: false,
+      })
+    })
+
+    it('should allow toggling from true to false', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(true)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-false'))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: false,
+        })
+      )
+    })
+
+    it('should allow toggling from false to true', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(false)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-true'))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: true,
+        })
+      )
+    })
+
+    it('should call onChange even when clicking already selected value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(true)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('boolean-toggle-true'))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: true,
+        })
+      )
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle undefined value like null', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'neverWatched',
+        operator: 'equals',
+        value: null,
+      }
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      const trueButton = screen.getByTestId('boolean-toggle-true')
+      const falseButton = screen.getByTestId('boolean-toggle-false')
+
+      // Both should be secondary when value is null/undefined
+      expect(trueButton).toHaveAttribute('data-variant', 'secondary')
+      expect(falseButton).toHaveAttribute('data-variant', 'secondary')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have data-testid attributes for testing', () => {
+      const condition = createCondition(null)
+
+      render(<BooleanToggle condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('boolean-toggle-true')).toBeInTheDocument()
+      expect(screen.getByTestId('boolean-toggle-false')).toBeInTheDocument()
+    })
+
+    it('should render buttons in a flex container', () => {
+      const condition = createCondition(null)
+
+      const { container } = render(
+        <BooleanToggle condition={condition} onChange={mockOnChange} />
+      )
+
+      const wrapper = container.firstChild
+      expect(wrapper).toHaveClass('flex-1', 'flex')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/DateInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/DateInput.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import { DateInput } from '../DateInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('DateInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'addedAt',
+    operator: 'before',
+    value,
+  })
+
+  const getDateInput = (container: HTMLElement) => {
+    return container.querySelector('input[type="date"]') as HTMLInputElement
+  }
+
+  describe('Basic Rendering', () => {
+    it('should render date input', () => {
+      const condition = createCondition(null)
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('type', 'date')
+    })
+
+    it('should display current value', () => {
+      const condition = createCondition('2024-01-15')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('2024-01-15')
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle null value as empty string', () => {
+      const condition = createCondition(null)
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('')
+    })
+
+    it('should handle empty string value', () => {
+      const condition = createCondition('')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when value changes', () => {
+      const condition = createCondition('')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      fireEvent.change(input, { target: { value: '2024-06-15' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: '2024-06-15',
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when changing value', () => {
+      const condition = createCondition('')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      fireEvent.change(input, { target: { value: '2024-06-15' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'addedAt',
+        operator: 'before',
+        value: '2024-06-15',
+      })
+    })
+
+    it('should handle clearing the input', () => {
+      const condition = createCondition('2024-01-15')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      fireEvent.change(input, { target: { value: '' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: '',
+        })
+      )
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle different date formats in display', () => {
+      const condition = createCondition('2023-12-31')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('2023-12-31')
+    })
+
+    it('should handle first day of year', () => {
+      const condition = createCondition('2024-01-01')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('2024-01-01')
+    })
+
+    it('should handle last day of year', () => {
+      const condition = createCondition('2024-12-31')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveValue('2024-12-31')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper input styling classes', () => {
+      const condition = createCondition('')
+
+      const { container } = render(<DateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = getDateInput(container)
+      expect(input).toHaveClass('flex-1')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/DateRangeInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/DateRangeInput.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DateRangeInput } from '../DateRangeInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('DateRangeInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string[] | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'addedAt',
+    operator: 'between',
+    value,
+  })
+
+  const getDateInputs = (container: HTMLElement) => {
+    return container.querySelectorAll('input[type="date"]') as NodeListOf<HTMLInputElement>
+  }
+
+  describe('Basic Rendering', () => {
+    it('should render two date inputs', () => {
+      const condition = createCondition(['', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs).toHaveLength(2)
+      expect(inputs[0]).toHaveAttribute('type', 'date')
+      expect(inputs[1]).toHaveAttribute('type', 'date')
+    })
+
+    it('should render "to" separator between inputs', () => {
+      const condition = createCondition(['', ''])
+
+      render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('to')).toBeInTheDocument()
+    })
+
+    it('should display current start and end values', () => {
+      const condition = createCondition(['2024-01-01', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('2024-01-01')
+      expect(inputs[1]).toHaveValue('2024-12-31')
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle null value as empty strings', () => {
+      const condition = createCondition(null)
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('')
+      expect(inputs[1]).toHaveValue('')
+    })
+
+    it('should handle partial values', () => {
+      const condition = createCondition(['2024-01-01', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('2024-01-01')
+      expect(inputs[1]).toHaveValue('')
+    })
+
+    it('should handle only end date provided', () => {
+      const condition = createCondition(['', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('')
+      expect(inputs[1]).toHaveValue('2024-12-31')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when start date changes', () => {
+      const condition = createCondition(['', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[0], { target: { value: '2024-01-01' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['2024-01-01', '2024-12-31'],
+        })
+      )
+    })
+
+    it('should call onChange when end date changes', () => {
+      const condition = createCondition(['2024-01-01', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[1], { target: { value: '2024-12-31' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['2024-01-01', '2024-12-31'],
+        })
+      )
+    })
+
+    it('should preserve end date when changing start date', () => {
+      const condition = createCondition(['', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[0], { target: { value: '2024-01-01' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['2024-01-01', '2024-12-31'],
+        })
+      )
+    })
+
+    it('should preserve start date when changing end date', () => {
+      const condition = createCondition(['2024-01-01', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[1], { target: { value: '2024-12-31' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['2024-01-01', '2024-12-31'],
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when changing dates', () => {
+      const condition = createCondition(['', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[0], { target: { value: '2024-01-01' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'addedAt',
+        operator: 'between',
+        value: ['2024-01-01', ''],
+      })
+    })
+
+    it('should handle clearing start date', () => {
+      const condition = createCondition(['2024-01-01', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[0], { target: { value: '' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['', '2024-12-31'],
+        })
+      )
+    })
+
+    it('should handle clearing end date', () => {
+      const condition = createCondition(['2024-01-01', '2024-12-31'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      fireEvent.change(inputs[1], { target: { value: '' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['2024-01-01', ''],
+        })
+      )
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle same start and end date', () => {
+      const condition = createCondition(['2024-06-15', '2024-06-15'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('2024-06-15')
+      expect(inputs[1]).toHaveValue('2024-06-15')
+    })
+
+    it('should handle year boundaries', () => {
+      const condition = createCondition(['2023-12-31', '2024-01-01'])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('2023-12-31')
+      expect(inputs[1]).toHaveValue('2024-01-01')
+    })
+
+    it('should handle empty array as initial value', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'addedAt',
+        operator: 'between',
+        value: [],
+      }
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveValue('')
+      expect(inputs[1]).toHaveValue('')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper input styling classes', () => {
+      const condition = createCondition(['', ''])
+
+      const { container } = render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = getDateInputs(container)
+      expect(inputs[0]).toHaveClass('flex-1')
+      expect(inputs[1]).toHaveClass('flex-1')
+    })
+
+    it('should display "to" separator with proper styling', () => {
+      const condition = createCondition(['', ''])
+
+      render(<DateRangeInput condition={condition} onChange={mockOnChange} />)
+
+      const separator = screen.getByText('to')
+      expect(separator).toHaveClass('text-slate-400')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/MultiSelectInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/MultiSelectInput.test.tsx
@@ -1,0 +1,500 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MultiSelectInput } from '../MultiSelectInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('MultiSelectInput', () => {
+  const mockOnChange = jest.fn()
+
+  const defaultOptions = [
+    { value: 'action', label: 'Action' },
+    { value: 'comedy', label: 'Comedy' },
+    { value: 'drama', label: 'Drama' },
+    { value: 'horror', label: 'Horror' },
+  ]
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string[] | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'genres',
+    operator: 'containsAny',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render all options as checkboxes', () => {
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes).toHaveLength(4)
+    })
+
+    it('should display option labels', () => {
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      expect(screen.getByText('Action')).toBeInTheDocument()
+      expect(screen.getByText('Comedy')).toBeInTheDocument()
+      expect(screen.getByText('Drama')).toBeInTheDocument()
+      expect(screen.getByText('Horror')).toBeInTheDocument()
+    })
+
+    it('should render checkboxes in a 2-column grid', () => {
+      const condition = createCondition([])
+
+      const { container } = render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const grid = container.querySelector('.grid-cols-2')
+      expect(grid).toBeInTheDocument()
+    })
+  })
+
+  describe('Value Display', () => {
+    it('should check boxes for selected values', () => {
+      const condition = createCondition(['action', 'drama'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes[0]).toBeChecked() // action
+      expect(checkboxes[1]).not.toBeChecked() // comedy
+      expect(checkboxes[2]).toBeChecked() // drama
+      expect(checkboxes[3]).not.toBeChecked() // horror
+    })
+
+    it('should handle empty array', () => {
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).not.toBeChecked()
+      })
+    })
+
+    it('should handle null value as empty array', () => {
+      const condition = createCondition(null)
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).not.toBeChecked()
+      })
+    })
+
+    it('should handle all values selected', () => {
+      const condition = createCondition(['action', 'comedy', 'drama', 'horror'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).toBeChecked()
+      })
+    })
+  })
+
+  describe('User Interactions - Selecting', () => {
+    it('should add value when unchecked option is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const actionCheckbox = screen.getAllByRole('checkbox')[0]
+      await user.click(actionCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['action'],
+        })
+      )
+    })
+
+    it('should append value to existing selections', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const comedyCheckbox = screen.getAllByRole('checkbox')[1]
+      await user.click(comedyCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['action', 'comedy'],
+        })
+      )
+    })
+
+    it('should allow selecting multiple values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action', 'comedy'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const dramaCheckbox = screen.getAllByRole('checkbox')[2]
+      await user.click(dramaCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['action', 'comedy', 'drama'],
+        })
+      )
+    })
+  })
+
+  describe('User Interactions - Deselecting', () => {
+    it('should remove value when checked option is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action', 'comedy'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const actionCheckbox = screen.getAllByRole('checkbox')[0]
+      await user.click(actionCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['comedy'],
+        })
+      )
+    })
+
+    it('should handle removing the only selected value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const actionCheckbox = screen.getAllByRole('checkbox')[0]
+      await user.click(actionCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [],
+        })
+      )
+    })
+
+    it('should handle removing from middle of selected values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action', 'comedy', 'drama'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const comedyCheckbox = screen.getAllByRole('checkbox')[1]
+      await user.click(comedyCheckbox)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['action', 'drama'],
+        })
+      )
+    })
+  })
+
+  describe('Preserving Condition Properties', () => {
+    it('should preserve condition field and operator when selecting', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      await user.click(screen.getAllByRole('checkbox')[0])
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'genres',
+        operator: 'containsAny',
+        value: ['action'],
+      })
+    })
+
+    it('should preserve condition field and operator when deselecting', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['action'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      await user.click(screen.getAllByRole('checkbox')[0])
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'genres',
+        operator: 'containsAny',
+        value: [],
+      })
+    })
+  })
+
+  describe('Different Option Sets', () => {
+    it('should work with resolution options', () => {
+      const resolutionOptions = [
+        { value: '4k', label: '4K UHD' },
+        { value: '1080p', label: 'Full HD' },
+        { value: '720p', label: 'HD' },
+        { value: '480p', label: 'SD' },
+      ]
+      const condition = createCondition(['4k', '1080p'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={resolutionOptions}
+        />
+      )
+
+      expect(screen.getByText('4K UHD')).toBeInTheDocument()
+      expect(screen.getByText('Full HD')).toBeInTheDocument()
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes[0]).toBeChecked() // 4k
+      expect(checkboxes[1]).toBeChecked() // 1080p
+      expect(checkboxes[2]).not.toBeChecked() // 720p
+    })
+
+    it('should work with single option', () => {
+      const singleOption = [{ value: 'only', label: 'Only Option' }]
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={singleOption}
+        />
+      )
+
+      expect(screen.getByText('Only Option')).toBeInTheDocument()
+      expect(screen.getAllByRole('checkbox')).toHaveLength(1)
+    })
+
+    it('should work with many options', () => {
+      const manyOptions = Array.from({ length: 10 }, (_, i) => ({
+        value: `option${i + 1}`,
+        label: `Option ${i + 1}`,
+      }))
+      const condition = createCondition(['option1', 'option5', 'option10'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={manyOptions}
+        />
+      )
+
+      expect(screen.getByText('Option 1')).toBeInTheDocument()
+      expect(screen.getByText('Option 10')).toBeInTheDocument()
+      expect(screen.getAllByRole('checkbox')).toHaveLength(10)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle options with special characters in labels', () => {
+      const specialOptions = [
+        { value: 'sci-fi', label: 'Sci-Fi & Fantasy' },
+        { value: 'kids', label: "Kids' Shows" },
+        { value: 'documentary', label: 'Documentary/Non-Fiction' },
+      ]
+      const condition = createCondition(['sci-fi'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={specialOptions}
+        />
+      )
+
+      expect(screen.getByText('Sci-Fi & Fantasy')).toBeInTheDocument()
+      expect(screen.getByText("Kids' Shows")).toBeInTheDocument()
+      expect(screen.getByText('Documentary/Non-Fiction')).toBeInTheDocument()
+    })
+
+    it('should handle empty options array', () => {
+      const condition = createCondition([])
+
+      const { container } = render(
+        <MultiSelectInput condition={condition} onChange={mockOnChange} options={[]} />
+      )
+
+      expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
+      // Container should still render
+      expect(container.firstChild).toBeInTheDocument()
+    })
+
+    it('should handle value not in options', () => {
+      const condition = createCondition(['unknown'])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      // All checkboxes should be unchecked since 'unknown' is not in options
+      const checkboxes = screen.getAllByRole('checkbox')
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).not.toBeChecked()
+      })
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should associate labels with checkboxes', () => {
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      // Click on label text should toggle checkbox
+      const actionLabel = screen.getByText('Action')
+      expect(actionLabel.closest('label')).toBeInTheDocument()
+    })
+
+    it('should have clickable labels', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      // Clicking the label should trigger onChange
+      const actionLabel = screen.getByText('Action')
+      await user.click(actionLabel)
+
+      expect(mockOnChange).toHaveBeenCalled()
+    })
+
+    it('should have proper styling classes on labels', () => {
+      const condition = createCondition([])
+
+      render(
+        <MultiSelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const label = screen.getByText('Action').closest('label')
+      expect(label).toHaveClass('cursor-pointer')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/MultiTextInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/MultiTextInput.test.tsx
@@ -1,0 +1,357 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MultiTextInput } from '../MultiTextInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('MultiTextInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string[] | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'genres',
+    operator: 'containsAny',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render text input and Add button', () => {
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByPlaceholderText('Type and press Enter')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+    })
+
+    it('should not display tags when array is empty', () => {
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      // No tags should be visible
+      expect(screen.queryByText('×')).not.toBeInTheDocument()
+    })
+
+    it('should display existing values as tags', () => {
+      const condition = createCondition(['Action', 'Comedy', 'Drama'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('Action')).toBeInTheDocument()
+      expect(screen.getByText('Comedy')).toBeInTheDocument()
+      expect(screen.getByText('Drama')).toBeInTheDocument()
+    })
+
+    it('should display remove button for each tag', () => {
+      const condition = createCondition(['Tag1', 'Tag2'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButtons = screen.getAllByText('×')
+      expect(removeButtons).toHaveLength(2)
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle null value as empty array', () => {
+      const condition = createCondition(null)
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.queryByText('×')).not.toBeInTheDocument()
+    })
+
+    it('should handle undefined value as empty array', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'genres',
+        operator: 'containsAny',
+        value: null,
+      }
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.queryByText('×')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Adding Values', () => {
+    it('should add value when Add button is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'NewTag')
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['NewTag'],
+        })
+      )
+    })
+
+    it('should add value when Enter key is pressed', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'NewTag{Enter}')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['NewTag'],
+        })
+      )
+    })
+
+    it('should append to existing values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['Existing'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'New{Enter}')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['Existing', 'New'],
+        })
+      )
+    })
+
+    it('should clear input after adding value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'Test{Enter}')
+
+      // The input should be cleared
+      expect(input).toHaveValue('')
+    })
+
+    it('should trim whitespace from values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, '  SpacedTag  {Enter}')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['SpacedTag'],
+        })
+      )
+    })
+
+    it('should not add empty values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, '   {Enter}')
+
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('should not add value when clicking Add with empty input', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Removing Values', () => {
+    it('should remove value when × button is clicked', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['Tag1', 'Tag2', 'Tag3'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButtons = screen.getAllByText('×')
+      await user.click(removeButtons[1]) // Remove 'Tag2'
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['Tag1', 'Tag3'],
+        })
+      )
+    })
+
+    it('should remove first value correctly', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['First', 'Second'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButtons = screen.getAllByText('×')
+      await user.click(removeButtons[0])
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['Second'],
+        })
+      )
+    })
+
+    it('should remove last value correctly', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['First', 'Second'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButtons = screen.getAllByText('×')
+      await user.click(removeButtons[1])
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['First'],
+        })
+      )
+    })
+
+    it('should handle removing the only value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['OnlyTag'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButton = screen.getByText('×')
+      await user.click(removeButton)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [],
+        })
+      )
+    })
+  })
+
+  describe('Preserving Condition Properties', () => {
+    it('should preserve condition field and operator when adding', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'Test{Enter}')
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'genres',
+        operator: 'containsAny',
+        value: ['Test'],
+      })
+    })
+
+    it('should preserve condition field and operator when removing', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(['Tag1'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      await user.click(screen.getByText('×'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'genres',
+        operator: 'containsAny',
+        value: [],
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle special characters in values', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Type and press Enter')
+      await user.type(input, 'Sci-Fi & Fantasy{Enter}')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: ['Sci-Fi & Fantasy'],
+        })
+      )
+    })
+
+    it('should display special characters correctly', () => {
+      const condition = createCondition(['Sci-Fi & Fantasy', "Kids' Shows"])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('Sci-Fi & Fantasy')).toBeInTheDocument()
+      expect(screen.getByText("Kids' Shows")).toBeInTheDocument()
+    })
+
+    it('should handle many values', () => {
+      const manyValues = Array.from({ length: 20 }, (_, i) => `Tag${i + 1}`)
+      const condition = createCondition(manyValues)
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('Tag1')).toBeInTheDocument()
+      expect(screen.getByText('Tag20')).toBeInTheDocument()
+
+      const removeButtons = screen.getAllByText('×')
+      expect(removeButtons).toHaveLength(20)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper input placeholder', () => {
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByPlaceholderText('Type and press Enter')).toBeInTheDocument()
+    })
+
+    it('should have type="button" on Add button', () => {
+      const condition = createCondition([])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const addButton = screen.getByRole('button', { name: 'Add' })
+      expect(addButton).toHaveAttribute('type', 'button')
+    })
+
+    it('should have type="button" on remove buttons', () => {
+      const condition = createCondition(['Tag1'])
+
+      render(<MultiTextInput condition={condition} onChange={mockOnChange} />)
+
+      const removeButton = screen.getByText('×').closest('button')
+      expect(removeButton).toHaveAttribute('type', 'button')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/RangeInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/RangeInput.test.tsx
@@ -1,0 +1,342 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RangeInput } from '../RangeInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('RangeInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: number[] | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'playCount',
+    operator: 'between',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render two number inputs', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs).toHaveLength(2)
+      expect(inputs[0]).toHaveAttribute('placeholder', 'Min')
+      expect(inputs[1]).toHaveAttribute('placeholder', 'Max')
+    })
+
+    it('should render "to" separator between inputs', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('to')).toBeInTheDocument()
+    })
+
+    it('should display current min and max values', () => {
+      const condition = createCondition([5, 10])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(5)
+      expect(inputs[1]).toHaveValue(10)
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle null value as zeros', () => {
+      const condition = createCondition(null)
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(0)
+      expect(inputs[1]).toHaveValue(0)
+    })
+
+    it('should handle empty array as zeros', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'playCount',
+        operator: 'between',
+        value: [],
+      }
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      // Empty array defaults to [0, 0], but 0 displays as null in number inputs
+      expect(inputs[0]).toHaveValue(null)
+      expect(inputs[1]).toHaveValue(null)
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when min value changes', () => {
+      const condition = createCondition([0, 100])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '10' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [10, 100],
+        })
+      )
+    })
+
+    it('should call onChange when max value changes', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[1], { target: { value: '50' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [0, 50],
+        })
+      )
+    })
+
+    it('should preserve max when changing min', () => {
+      const condition = createCondition([0, 100])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '25' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [25, 100],
+        })
+      )
+    })
+
+    it('should preserve min when changing max', () => {
+      const condition = createCondition([25, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[1], { target: { value: '75' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [25, 75],
+        })
+      )
+    })
+
+    it('should preserve condition field and operator', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '5' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'playCount',
+        operator: 'between',
+        value: [5, 0],
+      })
+    })
+  })
+
+  describe('Unit Conversion - Bytes', () => {
+    const createBytesCondition = (value: number[]): Condition => ({
+      type: 'condition',
+      id: 'test-id',
+      field: 'fileSize',
+      operator: 'between',
+      value,
+    })
+
+    const oneGB = 1024 * 1024 * 1024
+
+    it('should convert bytes to GB for display', () => {
+      const condition = createBytesCondition([oneGB * 5, oneGB * 10])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="bytes" />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(5)
+      expect(inputs[1]).toHaveValue(10)
+    })
+
+    it('should display GB unit label', () => {
+      const condition = createBytesCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="bytes" />)
+
+      expect(screen.getByText('GB')).toBeInTheDocument()
+    })
+
+    it('should convert GB input to bytes for storage', () => {
+      const condition = createBytesCondition([0, oneGB * 100])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="bytes" />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '2' } })
+
+      // 2 GB converted to bytes
+      const expectedBytes = 2 * oneGB
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [expectedBytes, oneGB * 100],
+        })
+      )
+    })
+  })
+
+  describe('Unit Conversion - kbps', () => {
+    const createKbpsCondition = (value: number[]): Condition => ({
+      type: 'condition',
+      id: 'test-id',
+      field: 'bitrate',
+      operator: 'between',
+      value,
+    })
+
+    it('should convert kbps to Mbps for display', () => {
+      const condition = createKbpsCondition([5000, 10000]) // 5 Mbps, 10 Mbps
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="kbps" />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(5)
+      expect(inputs[1]).toHaveValue(10)
+    })
+
+    it('should display Mbps unit label', () => {
+      const condition = createKbpsCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="kbps" />)
+
+      expect(screen.getByText('Mbps')).toBeInTheDocument()
+    })
+
+    it('should convert Mbps input to kbps for storage', () => {
+      const condition = createKbpsCondition([0, 10000])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="kbps" />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      fireEvent.change(inputs[0], { target: { value: '3' } })
+
+      // 3 Mbps converted to kbps
+      const expectedKbps = 3000
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: [expectedKbps, 10000],
+        })
+      )
+    })
+  })
+
+  describe('Unit Conversion - Minutes', () => {
+    const createMinutesCondition = (value: number[]): Condition => ({
+      type: 'condition',
+      id: 'test-id',
+      field: 'duration',
+      operator: 'between',
+      value,
+    })
+
+    it('should display values without conversion for minutes', () => {
+      const condition = createMinutesCondition([30, 120])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="minutes" />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(30)
+      expect(inputs[1]).toHaveValue(120)
+    })
+
+    it('should display min unit label', () => {
+      const condition = createMinutesCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} unit="minutes" />)
+
+      expect(screen.getByText('min')).toBeInTheDocument()
+    })
+  })
+
+  describe('Min/Max Limits', () => {
+    it('should apply min attribute to both inputs', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} min={0} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveAttribute('min', '0')
+      expect(inputs[1]).toHaveAttribute('min', '0')
+    })
+
+    it('should apply max attribute to both inputs', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} max={100} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveAttribute('max', '100')
+      expect(inputs[1]).toHaveAttribute('max', '100')
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle decimal values', () => {
+      const condition = createCondition([1.5, 2.5])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(1.5)
+      expect(inputs[1]).toHaveValue(2.5)
+    })
+
+    it('should handle same min and max values', () => {
+      const condition = createCondition([50, 50])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveValue(50)
+      expect(inputs[1]).toHaveValue(50)
+    })
+
+    it('should not display unit label when no unit provided', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.queryByText('GB')).not.toBeInTheDocument()
+      expect(screen.queryByText('Mbps')).not.toBeInTheDocument()
+      expect(screen.queryByText('min')).not.toBeInTheDocument()
+    })
+
+    it('should have step="any" for decimal support', () => {
+      const condition = createCondition([0, 0])
+
+      render(<RangeInput condition={condition} onChange={mockOnChange} />)
+
+      const inputs = screen.getAllByRole('spinbutton')
+      expect(inputs[0]).toHaveAttribute('step', 'any')
+      expect(inputs[1]).toHaveAttribute('step', 'any')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/RelativeDateInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/RelativeDateInput.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RelativeDateInput } from '../RelativeDateInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+// Mock StyledDropdown component
+jest.mock('@/components/ui/styled-dropdown', () => ({
+  StyledDropdown: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    options: Array<{ value: string; label: string }>
+  }) => (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      data-testid="unit-dropdown"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+describe('RelativeDateInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (
+    value: number,
+    valueUnit: 'days' | 'months' | 'years' = 'days'
+  ): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'lastWatchedAt',
+    operator: 'olderThan',
+    value,
+    valueUnit,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render number input and unit dropdown', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByPlaceholderText('Enter number')).toBeInTheDocument()
+      expect(screen.getByTestId('unit-dropdown')).toBeInTheDocument()
+      expect(screen.getByText('ago')).toBeInTheDocument()
+    })
+
+    it('should display current value', () => {
+      const condition = createCondition(90)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      expect(input).toHaveValue(90)
+    })
+
+    it('should display current unit', () => {
+      const condition = createCondition(6, 'months')
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const dropdown = screen.getByTestId('unit-dropdown')
+      expect(dropdown).toHaveValue('months')
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle zero value', () => {
+      const condition = createCondition(0)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      expect(input).toHaveValue(0)
+    })
+
+    it('should default unit to days when not provided', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'lastWatchedAt',
+        operator: 'olderThan',
+        value: 30,
+      }
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const dropdown = screen.getByTestId('unit-dropdown')
+      expect(dropdown).toHaveValue('days')
+    })
+
+    it('should default value to 0 when null', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'lastWatchedAt',
+        operator: 'olderThan',
+        value: null,
+        valueUnit: 'days',
+      }
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      expect(input).toHaveValue(0)
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when number value changes', () => {
+      const condition = createCondition(0)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      fireEvent.change(input, { target: { value: '60' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: 60,
+        })
+      )
+    })
+
+    it('should call onChange when unit changes', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(30, 'days')
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const dropdown = screen.getByTestId('unit-dropdown')
+      await user.selectOptions(dropdown, 'months')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          valueUnit: 'months',
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when changing value', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      fireEvent.change(input, { target: { value: '7' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'lastWatchedAt',
+        operator: 'olderThan',
+        value: 7,
+        valueUnit: 'days',
+      })
+    })
+
+    it('should handle clearing value', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      fireEvent.change(input, { target: { value: '' } })
+
+      // After clearing, value should be 0
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: 0,
+        })
+      )
+    })
+  })
+
+  describe('Unit Options', () => {
+    it('should have days option', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('days')).toBeInTheDocument()
+    })
+
+    it('should have months option', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('months')).toBeInTheDocument()
+    })
+
+    it('should have years option', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('years')).toBeInTheDocument()
+    })
+
+    it('should switch from days to years', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition(365, 'days')
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const dropdown = screen.getByTestId('unit-dropdown')
+      await user.selectOptions(dropdown, 'years')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          valueUnit: 'years',
+        })
+      )
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle large numbers', () => {
+      const condition = createCondition(9999)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      expect(input).toHaveValue(9999)
+    })
+
+    it('should have min attribute of 1', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter number')
+      expect(input).toHaveAttribute('min', '1')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should render the "ago" label', () => {
+      const condition = createCondition(30)
+
+      render(<RelativeDateInput condition={condition} onChange={mockOnChange} />)
+
+      expect(screen.getByText('ago')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/SelectInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/SelectInput.test.tsx
@@ -1,0 +1,354 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SelectInput } from '../SelectInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+// Mock StyledDropdown component
+jest.mock('@/components/ui/styled-dropdown', () => ({
+  StyledDropdown: ({
+    value,
+    onChange,
+    options,
+    placeholder,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    options: Array<{ value: string; label: string }>
+    placeholder?: string
+  }) => (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      data-testid="select-input"
+    >
+      {placeholder && (
+        <option value="" disabled>
+          {placeholder}
+        </option>
+      )}
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+describe('SelectInput', () => {
+  const mockOnChange = jest.fn()
+
+  const defaultOptions = [
+    { value: '1080p', label: '1080p' },
+    { value: '720p', label: '720p' },
+    { value: '480p', label: '480p' },
+  ]
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'resolution',
+    operator: 'equals',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render a select dropdown', () => {
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      expect(screen.getByTestId('select-input')).toBeInTheDocument()
+    })
+
+    it('should render all provided options', () => {
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      expect(screen.getByText('1080p')).toBeInTheDocument()
+      expect(screen.getByText('720p')).toBeInTheDocument()
+      expect(screen.getByText('480p')).toBeInTheDocument()
+    })
+
+    it('should display placeholder text', () => {
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      expect(screen.getByText('Select...')).toBeInTheDocument()
+    })
+  })
+
+  describe('Value Display', () => {
+    it('should display current value', () => {
+      const condition = createCondition('720p')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      expect(select).toHaveValue('720p')
+    })
+
+    it('should handle empty string value', () => {
+      const condition = createCondition('')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      expect(select).toHaveValue('')
+    })
+
+    it('should handle null value as empty string', () => {
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      expect(select).toHaveValue('')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when value changes', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      await user.selectOptions(select, '1080p')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: '1080p',
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when changing value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      await user.selectOptions(select, '720p')
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        type: 'condition',
+        id: 'test-id',
+        field: 'resolution',
+        operator: 'equals',
+        value: '720p',
+      })
+    })
+
+    it('should allow changing from one value to another', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('1080p')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      await user.selectOptions(select, '480p')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: '480p',
+        })
+      )
+    })
+  })
+
+  describe('Different Option Sets', () => {
+    it('should work with quality options', () => {
+      const qualityOptions = [
+        { value: 'SD', label: 'SD (480p)' },
+        { value: 'HD', label: 'HD (720p)' },
+        { value: 'FHD', label: 'Full HD (1080p)' },
+        { value: 'UHD', label: '4K UHD' },
+      ]
+      const condition = createCondition('HD')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={qualityOptions}
+        />
+      )
+
+      expect(screen.getByText('SD (480p)')).toBeInTheDocument()
+      expect(screen.getByText('HD (720p)')).toBeInTheDocument()
+      expect(screen.getByText('Full HD (1080p)')).toBeInTheDocument()
+      expect(screen.getByText('4K UHD')).toBeInTheDocument()
+    })
+
+    it('should work with single option', () => {
+      const singleOption = [{ value: 'only', label: 'Only Option' }]
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={singleOption}
+        />
+      )
+
+      expect(screen.getByText('Only Option')).toBeInTheDocument()
+    })
+
+    it('should work with many options', () => {
+      const manyOptions = Array.from({ length: 10 }, (_, i) => ({
+        value: `option${i + 1}`,
+        label: `Option ${i + 1}`,
+      }))
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={manyOptions}
+        />
+      )
+
+      expect(screen.getByText('Option 1')).toBeInTheDocument()
+      expect(screen.getByText('Option 10')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle options with special characters in labels', () => {
+      const specialOptions = [
+        { value: 'hevc', label: 'H.265/HEVC' },
+        { value: 'avc', label: 'H.264/AVC' },
+        { value: 'av1', label: 'AV1 (AOMedia)' },
+      ]
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={specialOptions}
+        />
+      )
+
+      expect(screen.getByText('H.265/HEVC')).toBeInTheDocument()
+      expect(screen.getByText('H.264/AVC')).toBeInTheDocument()
+      expect(screen.getByText('AV1 (AOMedia)')).toBeInTheDocument()
+    })
+
+    it('should handle options where value differs from label', () => {
+      const diffOptions = [
+        { value: 'en', label: 'English' },
+        { value: 'es', label: 'Spanish' },
+        { value: 'fr', label: 'French' },
+      ]
+      const condition = createCondition('es')
+
+      render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={diffOptions}
+        />
+      )
+
+      const select = screen.getByTestId('select-input')
+      expect(select).toHaveValue('es')
+      expect(screen.getByText('Spanish')).toBeInTheDocument()
+    })
+
+    it('should handle empty options array', () => {
+      const condition = createCondition(null)
+
+      render(
+        <SelectInput condition={condition} onChange={mockOnChange} options={[]} />
+      )
+
+      const select = screen.getByTestId('select-input')
+      expect(select).toBeInTheDocument()
+      // Only placeholder should be present
+      expect(screen.getByText('Select...')).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should wrap in flex container', () => {
+      const condition = createCondition(null)
+
+      const { container } = render(
+        <SelectInput
+          condition={condition}
+          onChange={mockOnChange}
+          options={defaultOptions}
+        />
+      )
+
+      const wrapper = container.firstChild
+      expect(wrapper).toHaveClass('flex-1')
+    })
+  })
+})

--- a/components/maintenance/inputs/__tests__/StringInput.test.tsx
+++ b/components/maintenance/inputs/__tests__/StringInput.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { StringInput } from '../StringInput'
+import type { Condition } from '@/lib/validations/maintenance'
+
+describe('StringInput', () => {
+  const mockOnChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnChange.mockClear()
+  })
+
+  const createCondition = (value: string | null): Condition => ({
+    type: 'condition',
+    id: 'test-id',
+    field: 'title',
+    operator: 'contains',
+    value,
+  })
+
+  describe('Basic Rendering', () => {
+    it('should render text input with default placeholder', () => {
+      const condition = createCondition(null)
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('type', 'text')
+    })
+
+    it('should render with custom placeholder', () => {
+      const condition = createCondition(null)
+
+      render(
+        <StringInput
+          condition={condition}
+          onChange={mockOnChange}
+          placeholder="Enter title"
+        />
+      )
+
+      expect(screen.getByPlaceholderText('Enter title')).toBeInTheDocument()
+    })
+
+    it('should display current value', () => {
+      const condition = createCondition('test value')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue('test value')
+    })
+  })
+
+  describe('Value Handling', () => {
+    it('should handle null value as empty string', () => {
+      const condition = createCondition(null)
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue('')
+    })
+
+    it('should handle undefined-like value as empty string', () => {
+      const condition: Condition = {
+        type: 'condition',
+        id: 'test-id',
+        field: 'title',
+        operator: 'contains',
+        value: '',
+      }
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue('')
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call onChange when value changes', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      await user.type(input, 'x')
+
+      // Each character typed triggers onChange
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: 'x',
+        })
+      )
+    })
+
+    it('should preserve condition field and operator when changing value', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      await user.type(input, 'x')
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'condition',
+          id: 'test-id',
+          field: 'title',
+          operator: 'contains',
+          value: 'x',
+        })
+      )
+    })
+
+    it('should handle clearing the input', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('existing value')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      await user.clear(input)
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: '',
+        })
+      )
+    })
+
+    it('should handle pasting text', async () => {
+      const user = userEvent.setup()
+      const condition = createCondition('')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      await user.click(input)
+      await user.paste('pasted text')
+
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall.value).toBe('pasted text')
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle special characters in display', () => {
+      const condition = createCondition('!@#$%^&*()')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue('!@#$%^&*()')
+    })
+
+    it('should handle whitespace in display', () => {
+      const condition = createCondition('  spaces  ')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue('  spaces  ')
+    })
+
+    it('should handle long text', () => {
+      const longText = 'a'.repeat(1000)
+      const condition = createCondition(longText)
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveValue(longText)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper input styling classes', () => {
+      const condition = createCondition('')
+
+      render(<StringInput condition={condition} onChange={mockOnChange} />)
+
+      const input = screen.getByPlaceholderText('Enter value')
+      expect(input).toHaveClass('flex-1')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for 11 extracted maintenance components
- Tests cover input components (StringInput, NumberInput, DateInput, etc.)
- Tests cover rule components (RuleList, RuleActions)
- All tests follow project patterns using Jest + Testing Library

Closes #58

## Test Coverage

### Input Components (9 new test files)
- `StringInput.test.tsx` - Text input with placeholder and value handling
- `DateInput.test.tsx` - Date picker with date value handling
- `RelativeDateInput.test.tsx` - Relative date with number + unit dropdown
- `DateRangeInput.test.tsx` - Date range with start/end date inputs
- `RangeInput.test.tsx` - Numeric range with min/max and unit conversion
- `BooleanToggle.test.tsx` - True/False button toggle
- `MultiTextInput.test.tsx` - Tag-style multi-value text input
- `SelectInput.test.tsx` - Single select dropdown
- `MultiSelectInput.test.tsx` - Checkbox-based multi-select

### Rule Components (2 new test files)
- `RuleList.test.tsx` - Rule table with toggle, scan, edit, delete actions
- `RuleActions.test.tsx` - Create rule link button

### Existing Tests (4 files already existed)
- `NumberInput.test.tsx` ✅ (already existed)
- `CandidateList.test.tsx` ✅ (already existed)
- `CandidateFilters.test.tsx` ✅ (already existed)
- `CandidateActions.test.tsx` ✅ (already existed)

## Test Results

All **206 new tests pass** covering:
- Rendering and display of values
- User interactions (onChange callbacks)
- Edge cases (null, empty, boundary values)
- Unit conversions (bytes↔GB, kbps↔Mbps)
- Accessibility (proper labels, test IDs)

## Test plan
- [x] Run `npm test` to verify all new tests pass
- [x] Run `npm run build` to check for type errors
- [x] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)