### PR TITLE
Update /sync-main to checkout and pull main branch

### DIFF
--- a/.claude/commands/sync-main.md
+++ b/.claude/commands/sync-main.md
@@ -1,30 +1,30 @@
 ---
-description: Fetch, rebase, and pull main branch with automatic stash/pop
+description: Switch to main branch, pull latest changes with automatic stash/pop
 ---
 
-You are an expert at Git operations. Your task is to safely sync the current branch with the latest changes from the main branch.
+You are an expert at Git operations. Your task is to safely switch to the main branch and pull the latest changes.
 
 ## Requirements
 
 1. Check if there are any uncommitted changes
 2. If there are uncommitted changes, stash them with a descriptive message
-3. Fetch the latest changes from origin
-4. Rebase the current branch onto origin/main
+3. Switch to the main branch
+4. Pull the latest changes from origin
 5. If changes were stashed, pop them back
-6. Handle any conflicts that arise during rebase
+6. Handle any conflicts that arise
 7. Provide clear status updates throughout the process
 
 ## Steps
 
-1. Run `git status` to check for uncommitted changes
+1. Run `git status` to check for uncommitted changes and current branch
 2. If uncommitted changes exist:
-   - Run `git stash push -m "Auto-stash before syncing with main - $(date)"`
+   - Run `git stash push -m "Auto-stash before syncing main - $(date)"`
    - Note the stash reference for later
-3. Run `git fetch origin` to get latest changes
-4. Run `git rebase origin/main` to rebase current branch
-5. If the rebase succeeds and changes were stashed:
+3. Run `git checkout main` to switch to main branch
+4. Run `git pull origin main` to get latest changes
+5. If changes were stashed:
    - Run `git stash pop` to restore uncommitted changes
-6. If conflicts occur during rebase:
+6. If conflicts occur:
    - Show the conflicting files
    - Provide guidance on how to resolve
    - Do NOT automatically resolve conflicts
@@ -33,7 +33,7 @@ You are an expert at Git operations. Your task is to safely sync the current bra
 ## Important Notes
 
 - NEVER force push unless explicitly requested by the user
-- If rebase fails, inform the user and leave the repository in a safe state
+- If checkout fails, inform the user and leave the repository in a safe state
 - If stash pop fails due to conflicts, keep the stash for manual recovery
 - Always verify the current branch before starting
 - Provide clear next steps if manual intervention is needed


### PR DESCRIPTION
## Summary
- Update `/sync-main` command to switch to main branch and pull instead of rebasing current branch

## Changes

**Previous behavior:** Rebase current branch onto `origin/main`

**New behavior:**
1. Stash uncommitted changes (if any)
2. `git checkout main` - switch to main branch
3. `git pull origin main` - pull latest changes
4. Restore stashed changes (if any)

## Test plan
- [ ] Run `/sync-main` from a feature branch
- [ ] Verify it switches to main and pulls
- [ ] Test with uncommitted changes to verify stash/pop works

🤖 Generated with [Claude Code](https://claude.com/claude-code)