### PR TITLE
fix(ci): prevent duplicate workflow runs on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Restrict `push` trigger to `main` branch only in the Build workflow
- Previously, pushing to a PR branch triggered both `push` and `pull_request` events, causing duplicate workflow runs

## Details
The `build.yml` workflow was configured with both `push` and `pull_request` triggers without branch restrictions. This caused every commit pushed to a PR branch to trigger two separate workflow runs.

**Before**: Push to PR branch → 2 workflow runs (push + pull_request)
**After**: Push to PR branch → 1 workflow run (pull_request only)

## Test plan
- [x] Verify this PR only triggers one Build workflow run (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)