### PR TITLE
feat(ci): use sticky comments for Claude code reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Enable `use_sticky_comment: true` in the Claude code review workflow
- Claude will now edit a single comment instead of creating new comments on each push

## Details
Previously, every push to a PR would create a new review comment from Claude, cluttering the PR conversation. With sticky comments enabled, Claude updates the same comment, keeping the PR clean.

## Test plan
- [x] Push multiple commits to a PR and verify Claude edits the existing comment instead of creating new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)