### PR TITLE
fix: ensure PR commands start from clean main branch and commit changes

### DIFF
--- a/.claude/commands/fix-pr-status-checks.md
+++ b/.claude/commands/fix-pr-status-checks.md
@@ -17,7 +17,14 @@ Automated PR status check repair workflow that diagnoses and fixes failing GitHu
 
 This command runs an automated agent that:
 
-1. **Discovery Phase**
+1. **Start from a clean main branch**
+   - Stash any local changes: `git stash --include-untracked` (if there are changes)
+   - Checkout main branch: `git checkout main`
+   - Fetch latest from origin: `git fetch origin`
+   - Reset main to match origin: `git reset --hard origin/main`
+   - Verify main is up to date: `git log -1 --oneline` and compare with `git log -1 --oneline origin/main`
+
+2. **Discovery Phase**
    - Validate PR number argument is provided
    - Fetch PR status checks: `gh pr checks <pr-number>`
    - Identify failing status checks
@@ -26,14 +33,14 @@ This command runs an automated agent that:
    - For each failing check, get run details and logs
    - Create todo list tracking all failures
 
-2. **Analysis Phase**
+3. **Analysis Phase**
    For each failure:
    - Categorize failure type (build, test, lint, type error, dependency, etc.)
    - Extract specific error messages and file locations
    - Identify root cause (changed APIs, missing dependencies, test failures, etc.)
    - Prioritize fixes (blocking issues first)
 
-3. **Fix Phase** (Iterative)
+4. **Fix Phase** (Iterative)
    For each identified issue:
    - Mark as "in_progress" in todo list
    - Apply appropriate fix based on failure type
@@ -46,20 +53,21 @@ This command runs an automated agent that:
      - Try alternative fix
      - Maximum 2 retry attempts per issue
 
-4. **Commit Phase**
-   - Stage all fixes
+5. **Commit Phase**
+   - Stage all fixes: `git add -A`
    - Create descriptive commit message with all fixes
-   - Push to PR branch
+   - Commit changes: `git commit -m "fix: resolve failing status checks for PR #<pr-number>"`
+   - Push to PR branch: `git push origin <branch-name>`
    - Link commit to PR in message: "Fixes failing status checks for PR #<pr-number>"
 
-5. **Verification Phase**
+6. **Verification Phase**
    - Wait for status checks to update after push
    - Check PR status: `gh pr checks <pr-number>`
    - Verify which checks now pass
    - For any checks that can be manually re-run, offer to trigger them
    - Report success or remaining failures
 
-6. **Documentation Phase**
+7. **Documentation Phase**
    - Summary of all fixes applied
    - PR URL with current status check results
    - Any issues requiring manual intervention

--- a/.claude/commands/update-pr.md
+++ b/.claude/commands/update-pr.md
@@ -7,22 +7,28 @@ tags:
 
 You are tasked with updating a pull request by rebasing it and addressing review comments. Follow these steps:
 
-1. **Fetch the PR details** using the `gh` CLI:
+1. **Start from a clean main branch**:
+   - Stash any local changes: `git stash --include-untracked` (if there are changes)
+   - Checkout main branch: `git checkout main`
+   - Fetch latest from origin: `git fetch origin`
+   - Reset main to match origin: `git reset --hard origin/main`
+   - Verify main is up to date: `git log -1 --oneline` and compare with `git log -1 --oneline origin/main`
+
+2. **Fetch the PR details** using the `gh` CLI:
    - Use `gh pr view <pr-number> --json number,title,body,state,headRefName,reviews,comments`
    - Parse the JSON response to extract PR info and review feedback
    - Also run `gh pr diff <pr-number>` to see the changes
 
-2. **Check for review comments**:
+3. **Check for review comments**:
    - Use `gh api repos/{owner}/{repo}/pulls/<pr-number>/comments` to get inline code review comments
    - Look for any change requests or suggestions in the reviews
    - Identify specific action items that need to be addressed
 
-3. **Checkout and update the PR branch**:
-   - Run `git fetch origin` to get latest changes
+4. **Checkout and update the PR branch**:
    - Checkout the PR branch: `git checkout <headRefName>`
    - Verify current branch with `git branch --show-current`
 
-4. **Rebase on main**:
+5. **Rebase on main**:
    - Run `git rebase origin/main`
    - If conflicts occur, resolve them carefully:
      - Use `git status` to see conflicted files
@@ -31,28 +37,31 @@ You are tasked with updating a pull request by rebasing it and addressing review
      - Continue rebase with `git rebase --continue`
    - If rebase fails and you can't resolve it, inform the user
 
-5. **Create implementation plan for addressing comments**:
+6. **Create implementation plan for addressing comments**:
    - Use the TodoWrite tool to track tasks for addressing review comments
    - Include specific tasks for each requested change
    - Add verification tasks (tests, build, lint)
 
-6. **Address review comments**:
+7. **Address review comments**:
    - Implement each requested change from the review
    - Follow project conventions from CLAUDE.md
    - Mark todos as in_progress/completed as you work
    - Ensure changes align with the reviewer's feedback
 
-7. **Verify changes**:
+8. **Verify changes**:
    - Run relevant tests: `npm test` or specific test files
    - Run build: `npm run build`
    - Run lint: `npm run lint`
    - Ensure all checks pass
 
-8. **Push updated branch**:
+9. **Commit and push updated branch**:
+   - Stage all changes: `git add -A`
+   - Create a descriptive commit message summarizing the review feedback addressed
+   - Commit changes: `git commit -m "address PR review feedback: <summary of changes>"`
    - Push with force-with-lease to preserve history safely: `git push origin <branch-name> --force-with-lease`
    - Verify push was successful
 
-9. **Create GitHub issue for follow-up tasks** (if applicable):
+10. **Create GitHub issue for follow-up tasks** (if applicable):
    - Review all comments from the code review
    - Identify any items marked as:
      - "Optional but recommended"
@@ -89,7 +98,7 @@ You are tasked with updating a pull request by rebasing it and addressing review
        ```
    - Report the issue number to the user after creation
 
-10. **Provide summary**:
+11. **Provide summary**:
    - Summarize what review comments were addressed
    - Confirm the PR is rebased on latest main
    - List any verification steps completed


### PR DESCRIPTION
## Summary
- Updates `/update-pr` and `/fix-pr-status-checks` slash commands to always start from a clean main branch
- Ensures main is up to date with origin before checking out PR branches
- Adds explicit commit and push steps after applying fixes

## Changes
- Added new "Start from a clean main branch" step to both commands that:
  - Stashes any local changes
  - Checks out main branch
  - Fetches and resets to origin/main
- Updated commit phase in both commands to explicitly stage and commit changes before pushing
- Renumbered all steps accordingly

## Test plan
- [ ] Run `/update-pr <pr-number>` and verify it starts from main
- [ ] Run `/fix-pr-status-checks <pr-number>` and verify it starts from main
- [ ] Verify changes are committed and pushed after fixes are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)