### PR TITLE
fix: update formatters tests to expect title case for unknown media types

### DIFF
--- a/lib/utils/__tests__/formatters.test.ts
+++ b/lib/utils/__tests__/formatters.test.ts
@@ -86,18 +86,23 @@ describe('formatters', () => {
       expect(getMediaTypeLabel('EPISODE')).toBe('Episode')
     })
 
-    it('should replace all underscores with spaces for unknown media types', () => {
-      expect(getMediaTypeLabel('TV_SHOW')).toBe('TV SHOW')
-      expect(getMediaTypeLabel('AUDIO_BOOK')).toBe('AUDIO BOOK')
-      expect(getMediaTypeLabel('TV_SHOW_EPISODE')).toBe('TV SHOW EPISODE')
+    it('should convert unknown media types to title case', () => {
+      expect(getMediaTypeLabel('TV_SHOW')).toBe('Tv Show')
+      expect(getMediaTypeLabel('AUDIO_BOOK')).toBe('Audio Book')
+      expect(getMediaTypeLabel('TV_SHOW_EPISODE')).toBe('Tv Show Episode')
     })
 
     it('should handle empty string', () => {
       expect(getMediaTypeLabel('')).toBe('')
     })
 
-    it('should handle strings without underscores', () => {
-      expect(getMediaTypeLabel('Movie')).toBe('Movie')
+    it('should convert strings without underscores to title case', () => {
+      expect(getMediaTypeLabel('CUSTOM')).toBe('Custom')
+      expect(getMediaTypeLabel('OTHER')).toBe('Other')
+    })
+
+    it('should handle multiple underscores and convert to title case', () => {
+      expect(getMediaTypeLabel('VERY_LONG_TYPE_NAME')).toBe('Very Long Type Name')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Updated test expectations in `lib/utils/__tests__/formatters.test.ts` to match the title case behavior of `getMediaTypeLabel`
- The implementation was already correct, but tests were outdated and expected ALL CAPS output

## Changes

- Changed test expectations from ALL CAPS to title case (e.g., `'TV SHOW'` → `'Tv Show'`)
- Renamed test descriptions to reflect title case behavior
- Added additional test cases for edge cases (multiple underscores, single words)

## Test plan

- [x] All 36 formatter tests pass across both test files
- [x] Verified title case conversion works for unknown media types

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)