### PR TITLE
feat: add SKIP_SEED option and Discord command logging migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e:headed": "playwright test --headed",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "db:migrate": "prisma migrate dev --skip-seed",
+    "db:migrate": "SKIP_SEED=true prisma migrate dev",
     "db:studio": "prisma studio",
     "db:seed": "prisma db seed",
     "register-discord-metadata": "ts-node --project tsconfig.scripts.json -r tsconfig-paths/register scripts/register-discord-metadata.ts"

--- a/prisma/migrations/20251129215232_latest/migration.sql
+++ b/prisma/migrations/20251129215232_latest/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "DiscordCommandType" AS ENUM ('CHAT', 'MEDIA_MARK', 'CLEAR_CONTEXT', 'SELECTION', 'LINK_REQUEST');
+
+-- CreateEnum
+CREATE TYPE "DiscordCommandStatus" AS ENUM ('PENDING', 'SUCCESS', 'FAILED', 'TIMEOUT');
+
+-- CreateTable
+CREATE TABLE "DiscordCommandLog" (
+    "id" TEXT NOT NULL,
+    "discordUserId" TEXT NOT NULL,
+    "discordUsername" TEXT,
+    "userId" TEXT,
+    "commandType" "DiscordCommandType" NOT NULL,
+    "commandName" TEXT NOT NULL,
+    "commandArgs" TEXT,
+    "channelId" TEXT NOT NULL,
+    "channelType" TEXT NOT NULL,
+    "guildId" TEXT,
+    "status" "DiscordCommandStatus" NOT NULL DEFAULT 'PENDING',
+    "error" TEXT,
+    "responseTimeMs" INTEGER,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DiscordCommandLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_discordUserId_idx" ON "DiscordCommandLog"("discordUserId");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_userId_idx" ON "DiscordCommandLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_commandType_idx" ON "DiscordCommandLog"("commandType");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_commandName_idx" ON "DiscordCommandLog"("commandName");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_status_idx" ON "DiscordCommandLog"("status");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_createdAt_idx" ON "DiscordCommandLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "DiscordCommandLog_channelId_idx" ON "DiscordCommandLog"("channelId");

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,12 @@
 import { PrismaClient } from '../lib/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
+// Allow skipping seed via environment variable (useful for migrations)
+if (process.env.SKIP_SEED === 'true') {
+  console.log('Skipping seed (SKIP_SEED=true)')
+  process.exit(0)
+}
+
 if (!process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL environment variable is not defined')
 }


### PR DESCRIPTION
## Summary
- Update `db:migrate` script to use `SKIP_SEED=true` environment variable instead of the deprecated `--skip-seed` flag
- Add `SKIP_SEED` environment variable check in `prisma/seed.ts` for early exit during migrations
- Add database migration for `DiscordCommandLog` table with `DiscordCommandType` and `DiscordCommandStatus` enums for tracking Discord bot command usage

## Test plan
- [ ] Run `npm run db:migrate` and verify seeding is skipped
- [ ] Verify the DiscordCommandLog table is created with correct schema
- [ ] Verify indexes are created on the new table

🤖 Generated with [Claude Code](https://claude.com/claude-code)