### PR TITLE
feat: add pagination for maintenance candidate listing

### DIFF
--- a/components/ui/__tests__/pagination.test.tsx
+++ b/components/ui/__tests__/pagination.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Pagination } from '@/components/ui/pagination'
+
+const defaultProps = {
+  page: 1,
+  pageSize: 25,
+  totalCount: 100,
+  totalPages: 4,
+  hasNextPage: true,
+  hasPreviousPage: false,
+  onPageChange: jest.fn(),
+}
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Display', () => {
+    it('should display correct page information', () => {
+      render(<Pagination {...defaultProps} />)
+
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent(
+        'Showing 1 to 25 of 100 results'
+      )
+      expect(screen.getByTestId('pagination-current-page')).toHaveTextContent('1')
+      expect(screen.getByTestId('pagination-total-pages')).toHaveTextContent('4')
+    })
+
+    it('should display correct range for middle page', () => {
+      render(<Pagination {...defaultProps} page={2} hasPreviousPage={true} />)
+
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent(
+        'Showing 26 to 50 of 100 results'
+      )
+    })
+
+    it('should display correct range for last page with partial results', () => {
+      render(
+        <Pagination
+          {...defaultProps}
+          page={4}
+          hasNextPage={false}
+          hasPreviousPage={true}
+        />
+      )
+
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent(
+        'Showing 76 to 100 of 100 results'
+      )
+    })
+
+    it('should display 0 to 0 of 0 when empty', () => {
+      render(
+        <Pagination
+          {...defaultProps}
+          page={1}
+          totalCount={0}
+          totalPages={0}
+          hasNextPage={false}
+          hasPreviousPage={false}
+        />
+      )
+
+      expect(screen.getByTestId('pagination-info')).toHaveTextContent(
+        'Showing 0 to 0 of 0 results'
+      )
+    })
+  })
+
+  describe('Navigation Buttons', () => {
+    it('should disable previous and first buttons on first page', () => {
+      render(<Pagination {...defaultProps} />)
+
+      expect(screen.getByTestId('pagination-first')).toBeDisabled()
+      expect(screen.getByTestId('pagination-previous')).toBeDisabled()
+      expect(screen.getByTestId('pagination-next')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-last')).not.toBeDisabled()
+    })
+
+    it('should disable next and last buttons on last page', () => {
+      render(
+        <Pagination
+          {...defaultProps}
+          page={4}
+          hasNextPage={false}
+          hasPreviousPage={true}
+        />
+      )
+
+      expect(screen.getByTestId('pagination-first')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-previous')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-next')).toBeDisabled()
+      expect(screen.getByTestId('pagination-last')).toBeDisabled()
+    })
+
+    it('should enable all navigation buttons on middle page', () => {
+      render(
+        <Pagination {...defaultProps} page={2} hasNextPage={true} hasPreviousPage={true} />
+      )
+
+      expect(screen.getByTestId('pagination-first')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-previous')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-next')).not.toBeDisabled()
+      expect(screen.getByTestId('pagination-last')).not.toBeDisabled()
+    })
+  })
+
+  describe('Navigation Actions', () => {
+    it('should call onPageChange with 1 when clicking first button', async () => {
+      const user = userEvent.setup()
+      const onPageChange = jest.fn()
+
+      render(
+        <Pagination
+          {...defaultProps}
+          page={3}
+          hasPreviousPage={true}
+          onPageChange={onPageChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('pagination-first'))
+
+      expect(onPageChange).toHaveBeenCalledWith(1)
+    })
+
+    it('should call onPageChange with page-1 when clicking previous button', async () => {
+      const user = userEvent.setup()
+      const onPageChange = jest.fn()
+
+      render(
+        <Pagination
+          {...defaultProps}
+          page={3}
+          hasPreviousPage={true}
+          onPageChange={onPageChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('pagination-previous'))
+
+      expect(onPageChange).toHaveBeenCalledWith(2)
+    })
+
+    it('should call onPageChange with page+1 when clicking next button', async () => {
+      const user = userEvent.setup()
+      const onPageChange = jest.fn()
+
+      render(<Pagination {...defaultProps} onPageChange={onPageChange} />)
+
+      await user.click(screen.getByTestId('pagination-next'))
+
+      expect(onPageChange).toHaveBeenCalledWith(2)
+    })
+
+    it('should call onPageChange with totalPages when clicking last button', async () => {
+      const user = userEvent.setup()
+      const onPageChange = jest.fn()
+
+      render(<Pagination {...defaultProps} onPageChange={onPageChange} />)
+
+      await user.click(screen.getByTestId('pagination-last'))
+
+      expect(onPageChange).toHaveBeenCalledWith(4)
+    })
+  })
+
+  describe('Page Size Selection', () => {
+    it('should not show page size selector when onPageSizeChange is not provided', () => {
+      render(<Pagination {...defaultProps} />)
+
+      expect(screen.queryByTestId('pagination-page-size')).not.toBeInTheDocument()
+    })
+
+    it('should show page size selector when onPageSizeChange is provided', () => {
+      const onPageSizeChange = jest.fn()
+
+      render(<Pagination {...defaultProps} onPageSizeChange={onPageSizeChange} />)
+
+      expect(screen.getByTestId('pagination-page-size')).toBeInTheDocument()
+    })
+
+    it('should call onPageSizeChange with selected value', async () => {
+      const user = userEvent.setup()
+      const onPageSizeChange = jest.fn()
+
+      render(<Pagination {...defaultProps} onPageSizeChange={onPageSizeChange} />)
+
+      await user.selectOptions(screen.getByTestId('pagination-page-size'), '50')
+
+      expect(onPageSizeChange).toHaveBeenCalledWith(50)
+    })
+
+    it('should show custom page size options', () => {
+      const onPageSizeChange = jest.fn()
+
+      render(
+        <Pagination
+          {...defaultProps}
+          onPageSizeChange={onPageSizeChange}
+          pageSizeOptions={[5, 15, 30]}
+        />
+      )
+
+      const select = screen.getByTestId('pagination-page-size')
+      expect(select).toContainHTML('<option value="5">5</option>')
+      expect(select).toContainHTML('<option value="15">15</option>')
+      expect(select).toContainHTML('<option value="30">30</option>')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have accessible labels for navigation buttons', () => {
+      render(<Pagination {...defaultProps} />)
+
+      expect(screen.getByLabelText('Go to first page')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to previous page')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to next page')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to last page')).toBeInTheDocument()
+    })
+  })
+
+  describe('Custom className', () => {
+    it('should apply custom className', () => {
+      render(<Pagination {...defaultProps} className="custom-class" />)
+
+      expect(screen.getByTestId('pagination')).toHaveClass('custom-class')
+    })
+  })
+})

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react"
+import { Button } from "./button"
+import { cn } from "@/lib/utils"
+
+interface PaginationProps {
+  page: number
+  pageSize: number
+  totalCount: number
+  totalPages: number
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  onPageChange: (page: number) => void
+  onPageSizeChange?: (pageSize: number) => void
+  pageSizeOptions?: number[]
+  className?: string
+}
+
+export function Pagination({
+  page,
+  pageSize,
+  totalCount,
+  totalPages,
+  hasNextPage,
+  hasPreviousPage,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [10, 25, 50, 100],
+  className,
+}: PaginationProps) {
+  const startItem = totalCount === 0 ? 0 : (page - 1) * pageSize + 1
+  const endItem = Math.min(page * pageSize, totalCount)
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4",
+        className
+      )}
+      data-testid="pagination"
+    >
+      <div className="flex items-center gap-4 text-sm text-slate-400">
+        <span data-testid="pagination-info">
+          Showing {startItem} to {endItem} of {totalCount} results
+        </span>
+        {onPageSizeChange && (
+          <div className="flex items-center gap-2">
+            <span>per page:</span>
+            <select
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              className="bg-slate-800 border border-slate-600 rounded px-2 py-1 text-slate-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+              data-testid="pagination-page-size"
+            >
+              {pageSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onPageChange(1)}
+          disabled={!hasPreviousPage}
+          aria-label="Go to first page"
+          data-testid="pagination-first"
+        >
+          <ChevronsLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onPageChange(page - 1)}
+          disabled={!hasPreviousPage}
+          aria-label="Go to previous page"
+          data-testid="pagination-previous"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+
+        <div className="flex items-center gap-1 px-2">
+          <span className="text-sm text-slate-400">
+            Page{" "}
+            <span className="text-white font-medium" data-testid="pagination-current-page">
+              {page}
+            </span>{" "}
+            of{" "}
+            <span className="text-white font-medium" data-testid="pagination-total-pages">
+              {totalPages}
+            </span>
+          </span>
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!hasNextPage}
+          aria-label="Go to next page"
+          data-testid="pagination-next"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onPageChange(totalPages)}
+          disabled={!hasNextPage}
+          aria-label="Go to last page"
+          data-testid="pagination-last"
+        >
+          <ChevronsRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/validations/maintenance.ts
+++ b/lib/validations/maintenance.ts
@@ -192,6 +192,17 @@ export type UpdateMaintenanceRule = z.infer<typeof UpdateMaintenanceRuleSchema>
 export type CreateUserMediaMark = z.infer<typeof CreateUserMediaMarkSchema>
 export type CreateUserWatchIntent = z.infer<typeof CreateUserWatchIntentSchema>
 
+// Pagination schema for candidate listing
+export const CandidatePaginationSchema = z.object({
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(100).default(25),
+  reviewStatus: ReviewStatusEnum.optional(),
+  mediaType: MediaTypeEnum.optional(),
+  scanId: z.string().optional(),
+})
+
+export type CandidatePagination = z.infer<typeof CandidatePaginationSchema>
+
 /**
  * Runtime validation for rule criteria
  * Validates field/operator compatibility and media type constraints

--- a/types/maintenance.ts
+++ b/types/maintenance.ts
@@ -193,6 +193,21 @@ export interface CandidateFilters {
 }
 
 /**
+ * Paginated response for maintenance candidates
+ */
+export interface PaginatedCandidatesResponse {
+  candidates: MaintenanceCandidate[]
+  pagination: {
+    page: number
+    pageSize: number
+    totalCount: number
+    totalPages: number
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+  }
+}
+
+/**
  * Maintenance rule with scan statistics
  */
 export interface RuleWithStats {


### PR DESCRIPTION
## Summary

Closes #38

- Add pagination to `getMaintenanceCandidates()` server action to prevent performance issues with large result sets
- Create reusable `Pagination` UI component with first/prev/next/last navigation
- Update candidates page to support page navigation and page size selection
- Add comprehensive tests for pagination logic (server action and component)

## Changes

### Server Action (`actions/maintenance.ts`)
- Accept `page` and `pageSize` parameters (defaults: page=1, pageSize=25)
- Use `skip`/`take` for database pagination
- Run count and findMany queries in parallel for performance
- Return `PaginatedCandidatesResponse` with candidates + pagination metadata

### Validation (`lib/validations/maintenance.ts`)
- Add `CandidatePaginationSchema` with Zod validation
- Page must be >= 1, pageSize between 1-100

### Types (`types/maintenance.ts`)
- Add `PaginatedCandidatesResponse` interface with pagination metadata

### UI Component (`components/ui/pagination.tsx`)
- Reusable pagination with first/prev/next/last buttons
- "Showing X to Y of Z results" display
- Optional page size selector dropdown
- Accessible with aria-labels
- `data-testid` attributes for E2E testing

### Candidates Page (`app/admin/maintenance/candidates/page.tsx`)
- Track page and pageSize state
- Reset page when filters or page size change
- Clear selection on page change
- Display pagination below candidate list

### Tests
- 9 new tests for `getMaintenanceCandidates` pagination logic
- 17 new tests for `Pagination` component

## Test plan

- [x] All unit tests pass (`npm test -- --testPathPatterns="maintenance|pagination"`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual testing: Navigate through pages of candidates
- [ ] Manual testing: Change page size and verify reset to page 1
- [ ] Manual testing: Apply filters and verify pagination updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)