### PR TITLE
feat: add configurable E2E test server port

### DIFF
--- a/example.env
+++ b/example.env
@@ -30,6 +30,10 @@ PLEX_CLIENT_IDENTIFIER=""
 # WARNING: Never enable this in production! Only for development/testing
 # NEXT_PUBLIC_ENABLE_TEST_AUTH="true"
 
+# E2E Test Server Port
+# Port for the dev server when running Playwright E2E tests (default: 3000)
+# E2E_PORT="3001"
+
 # Discord Bot / Linked Roles
 # ENABLE_DISCORD_BOT="true"  # Set to "false" to disable bot attempts (default: enabled)
 #                            # Uses distributed database lock - only one pod will run the bot automatically

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
+import 'dotenv/config';
 import { defineConfig, devices } from '@playwright/test';
 
+const port = process.env.E2E_PORT || '3000';
+const baseURL = `http://localhost:${port}`;
+console.log(`Running tests on ${baseURL}`);
 /**
  * See https://playwright.dev/docs/test-configuration
  */
@@ -19,7 +23,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -53,14 +57,14 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npx next dev',
-    url: 'http://localhost:3000',
+    command: `npx next dev -p ${port}`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 30000, // 30 seconds to allow for build/startup
     env: {
       ...process.env,
       NODE_ENV: 'test',
-      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+      NEXT_PUBLIC_APP_URL: baseURL,
       NEXT_PUBLIC_ENABLE_TEST_AUTH: 'true',
       ENABLE_TEST_AUTH: 'true',
       SKIP_CONNECTION_TESTS: 'true',


### PR DESCRIPTION
## Summary
- Add `E2E_PORT` environment variable to allow running Playwright tests on a custom port
- Update `playwright.config.ts` to use configurable port instead of hardcoded 3000
- Document the new variable in `example.env`

This helps avoid port conflicts when the default port 3000 is already in use by another service.

## Test plan
- [x] Verify tests still run on default port 3000 when E2E_PORT is not set
- [ ] Verify tests run on custom port when E2E_PORT is set (e.g., `E2E_PORT=3001`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)