### PR TITLE
fix: use SKIP_SEED env var for db:reset task

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -71,7 +71,7 @@ run = [
 
 [tasks."db:reset"]
 description = "Reset the database (delete and recreate)"
-run = "npx prisma migrate reset --skip-seed"
+run = "SKIP_SEED=true npx prisma migrate reset"
 
 [tasks.ci]
 description = "Run CI checks (matches GitHub Actions workflow)"


### PR DESCRIPTION
## Summary
- Replace `--skip-seed` flag with `SKIP_SEED=true` environment variable for Prisma migrate reset command
- Aligns with the seed script's environment variable check for skipping database seeding

## Test plan
- [ ] Run `mise run db:reset` and verify it resets without seeding
- [ ] Verify normal `mise run db:seed` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)