### PR TITLE
feat: add error context to scanner error messages

### DIFF
--- a/lib/maintenance/__tests__/scanner.test.ts
+++ b/lib/maintenance/__tests__/scanner.test.ts
@@ -640,9 +640,11 @@ describe('scanForCandidates', () => {
       // Execute
       const result = await scanForCandidates(mockRuleId)
 
-      // Verify error
+      // Verify error includes rule context
       expect(result.status).toBe('FAILED')
-      expect(result.error).toBe('Movie rules must specify libraryIds in criteria')
+      expect(result.error).toContain('MOVIE rules must specify libraryIds in criteria')
+      expect(result.error).toContain('Rule: "Test Rule"')
+      expect(result.error).toContain(mockRuleId)
     })
 
     it('should handle missing libraryIds for TV series rules', async () => {
@@ -666,9 +668,11 @@ describe('scanForCandidates', () => {
       // Execute
       const result = await scanForCandidates(mockRuleId)
 
-      // Verify error
+      // Verify error includes rule context
       expect(result.status).toBe('FAILED')
-      expect(result.error).toBe('TV series rules must specify libraryIds in criteria')
+      expect(result.error).toContain('TV_SERIES rules must specify libraryIds in criteria')
+      expect(result.error).toContain('Rule: "Test Rule"')
+      expect(result.error).toContain(mockRuleId)
     })
 
     it('should handle unsupported media type', async () => {
@@ -688,9 +692,12 @@ describe('scanForCandidates', () => {
       // Execute
       const result = await scanForCandidates(mockRuleId)
 
-      // Verify error
+      // Verify error includes rule context and supported types
       expect(result.status).toBe('FAILED')
-      expect(result.error).toBe('Unsupported media type: MUSIC')
+      expect(result.error).toContain('Unsupported media type: MUSIC')
+      expect(result.error).toContain('Rule: "Test Rule"')
+      expect(result.error).toContain(mockRuleId)
+      expect(result.error).toContain('Supported types: MOVIE, TV_SERIES')
     })
 
     it('should handle error during candidate creation', async () => {

--- a/lib/maintenance/scanner.ts
+++ b/lib/maintenance/scanner.ts
@@ -406,8 +406,15 @@ export async function scanForCandidates(
         } else {
           // If no specific libraries, we need to get all movie libraries
           // For now, throw an error requiring library IDs
+          logger.error("Rule validation failed", undefined, {
+            ruleId,
+            ruleName: rule.name,
+            mediaType: rule.mediaType,
+            error: "Missing libraryIds in criteria",
+          })
           throw new Error(
-            "Movie rules must specify libraryIds in criteria"
+            `${rule.mediaType} rules must specify libraryIds in criteria. ` +
+              `Rule: "${rule.name}" (${ruleId})`
           )
         }
       } else if (rule.mediaType === "TV_SERIES") {
@@ -422,12 +429,29 @@ export async function scanForCandidates(
         } else {
           // If no specific libraries, we need to get all TV libraries
           // For now, throw an error requiring library IDs
+          logger.error("Rule validation failed", undefined, {
+            ruleId,
+            ruleName: rule.name,
+            mediaType: rule.mediaType,
+            error: "Missing libraryIds in criteria",
+          })
           throw new Error(
-            "TV series rules must specify libraryIds in criteria"
+            `${rule.mediaType} rules must specify libraryIds in criteria. ` +
+              `Rule: "${rule.name}" (${ruleId})`
           )
         }
       } else {
-        throw new Error(`Unsupported media type: ${rule.mediaType}`)
+        logger.error("Rule validation failed", undefined, {
+          ruleId,
+          ruleName: rule.name,
+          mediaType: rule.mediaType,
+          error: "Unsupported media type",
+        })
+        throw new Error(
+          `Unsupported media type: ${rule.mediaType}. ` +
+            `Rule: "${rule.name}" (${ruleId}). ` +
+            `Supported types: MOVIE, TV_SERIES`
+        )
       }
 
       logger.debug("Fetched media items", {


### PR DESCRIPTION
## Summary

- Enhanced scanner error messages to include rule name, ID, and media type for easier debugging
- Added structured logging for rule validation failures with full context
- Updated tests to verify new error message format

Closes #33

## Test plan

- [x] All 19 scanner tests pass
- [x] Build completes successfully
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)