### PR TITLE
refactor: extract fetchWithTimeout utility for HTTP client requests

### DIFF
--- a/lib/connections/overseerr.ts
+++ b/lib/connections/overseerr.ts
@@ -1,4 +1,5 @@
 import { type OverseerrParsed } from "@/lib/validations/overseerr";
+import { fetchWithTimeout, isTimeoutError } from "@/lib/utils/fetch-with-timeout";
 
 export async function testOverseerrConnection(config: OverseerrParsed): Promise<{ success: boolean; error?: string }> {
   // TEST MODE BYPASS - Skip connection tests in test environment
@@ -10,19 +11,13 @@ export async function testOverseerrConnection(config: OverseerrParsed): Promise<
   try {
     const url = `${config.url}/api/v1/auth/me`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
         "X-Api-Key": config.apiKey,
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
@@ -43,10 +38,10 @@ export async function testOverseerrConnection(config: OverseerrParsed): Promise<
 
     return { success: true }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout - check your hostname and port" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout - check your hostname and port" }
-      }
       return { success: false, error: `Connection error: ${error.message}` }
     }
     return { success: false, error: "Failed to connect to Overseerr server" }

--- a/lib/connections/plex-search.ts
+++ b/lib/connections/plex-search.ts
@@ -3,6 +3,7 @@
  */
 
 import { type PlexServerParsed } from "@/lib/validations/plex"
+import { fetchWithTimeout, isTimeoutError } from "@/lib/utils/fetch-with-timeout"
 import { logger, type PlexMediaItem } from "./plex-core"
 
 /**
@@ -33,18 +34,12 @@ export async function searchPlexMedia(
       url += `&type=${typeCodeMap[mediaType]}`
     }
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000)
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       const duration = Date.now() - startTime
@@ -98,10 +93,10 @@ export async function searchPlexMedia(
   } catch (error) {
     const duration = Date.now() - startTime
     logger.error("Error searching Plex media", error, { query, mediaType, duration })
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout" }
-      }
       return { success: false, error: `Error searching media: ${error.message}` }
     }
     return { success: false, error: "Failed to search Plex media" }

--- a/lib/connections/plex-sessions.ts
+++ b/lib/connections/plex-sessions.ts
@@ -2,6 +2,8 @@
  * Plex session and library management functions
  */
 
+import { fetchWithTimeout, isTimeoutError } from "@/lib/utils/fetch-with-timeout"
+
 /**
  * Fetches current sessions from Plex server
  * Uses the Plex server API /status/sessions endpoint
@@ -12,18 +14,12 @@ export async function getPlexSessions(
   try {
     const url = `${serverConfig.url}/status/sessions?X-Plex-Token=${serverConfig.token}`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       return { success: false, error: `Failed to fetch sessions: ${response.statusText}` }
@@ -32,10 +28,10 @@ export async function getPlexSessions(
     const data = await response.json()
     return { success: true, data }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout" }
-      }
       return { success: false, error: `Error fetching sessions: ${error.message}` }
     }
     return { success: false, error: "Failed to fetch Plex sessions" }
@@ -51,18 +47,12 @@ export async function getPlexLibrarySections(
   try {
     const url = `${serverConfig.url}/library/sections?X-Plex-Token=${serverConfig.token}`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000)
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       return { success: false, error: `Failed to fetch library sections: ${response.statusText}` }
@@ -71,10 +61,10 @@ export async function getPlexLibrarySections(
     const data = await response.json()
     return { success: true, data }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout" }
-      }
       return { success: false, error: `Error fetching library sections: ${error.message}` }
     }
     return { success: false, error: "Failed to fetch Plex library sections" }
@@ -91,18 +81,12 @@ export async function getPlexRecentlyAdded(
   try {
     const url = `${serverConfig.url}/library/recentlyAdded?X-Plex-Token=${serverConfig.token}&limit=${limit}`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000)
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       return { success: false, error: `Failed to fetch recently added: ${response.statusText}` }
@@ -111,10 +95,10 @@ export async function getPlexRecentlyAdded(
     const data = await response.json()
     return { success: true, data }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout" }
-      }
       return { success: false, error: `Error fetching recently added: ${error.message}` }
     }
     return { success: false, error: "Failed to fetch Plex recently added" }
@@ -130,18 +114,12 @@ export async function getPlexOnDeck(
   try {
     const url = `${serverConfig.url}/library/onDeck?X-Plex-Token=${serverConfig.token}`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000)
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       return { success: false, error: `Failed to fetch on deck: ${response.statusText}` }
@@ -150,10 +128,10 @@ export async function getPlexOnDeck(
     const data = await response.json()
     return { success: true, data }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout" }
-      }
       return { success: false, error: `Error fetching on deck: ${error.message}` }
     }
     return { success: false, error: "Failed to fetch Plex on deck" }

--- a/lib/connections/radarr.ts
+++ b/lib/connections/radarr.ts
@@ -1,4 +1,5 @@
 import { type RadarrParsed } from "@/lib/validations/radarr";
+import { fetchWithTimeout, isTimeoutError } from "@/lib/utils/fetch-with-timeout";
 
 export async function testRadarrConnection(config: RadarrParsed): Promise<{ success: boolean; error?: string }> {
   // TEST MODE BYPASS - Skip connection tests in test environment
@@ -10,19 +11,13 @@ export async function testRadarrConnection(config: RadarrParsed): Promise<{ succ
   try {
     const url = `${config.url}/api/v3/system/status`
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
-
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       method: "GET",
       headers: {
         "Accept": "application/json",
         "X-Api-Key": config.apiKey,
       },
-      signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
@@ -43,10 +38,10 @@ export async function testRadarrConnection(config: RadarrParsed): Promise<{ succ
 
     return { success: true }
   } catch (error) {
+    if (isTimeoutError(error)) {
+      return { success: false, error: "Connection timeout - check your hostname and port" }
+    }
     if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        return { success: false, error: "Connection timeout - check your hostname and port" }
-      }
       return { success: false, error: `Connection error: ${error.message}` }
     }
     return { success: false, error: "Failed to connect to Radarr server" }

--- a/lib/utils/__tests__/fetch-with-timeout.test.ts
+++ b/lib/utils/__tests__/fetch-with-timeout.test.ts
@@ -1,0 +1,186 @@
+import { fetchWithTimeout, isTimeoutError } from '../fetch-with-timeout'
+
+// Mock global fetch
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+describe('fetch-with-timeout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('fetchWithTimeout', () => {
+    it('should call fetch with the provided URL and options', async () => {
+      const mockResponse = new Response(JSON.stringify({ data: 'test' }), { status: 200 })
+      mockFetch.mockResolvedValueOnce(mockResponse)
+
+      const promise = fetchWithTimeout('https://api.example.com/data', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      })
+
+      // Fast-forward timers to ensure any pending operations complete
+      jest.runAllTimers()
+      const response = await promise
+
+      expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: expect.any(AbortSignal),
+      })
+      expect(response).toBe(mockResponse)
+    })
+
+    it('should use default timeout of 10000ms', async () => {
+      const abortSpy = jest.spyOn(AbortController.prototype, 'abort')
+      mockFetch.mockImplementation(() => new Promise(() => {})) // Never resolves
+
+      fetchWithTimeout('https://api.example.com/data')
+
+      // Should not abort before 10000ms
+      jest.advanceTimersByTime(9999)
+      expect(abortSpy).not.toHaveBeenCalled()
+
+      // Should abort at 10000ms
+      jest.advanceTimersByTime(1)
+      expect(abortSpy).toHaveBeenCalled()
+
+      abortSpy.mockRestore()
+    })
+
+    it('should use custom timeout when provided', async () => {
+      const abortSpy = jest.spyOn(AbortController.prototype, 'abort')
+      mockFetch.mockImplementation(() => new Promise(() => {})) // Never resolves
+
+      fetchWithTimeout('https://api.example.com/data', { timeoutMs: 5000 })
+
+      // Should not abort before 5000ms
+      jest.advanceTimersByTime(4999)
+      expect(abortSpy).not.toHaveBeenCalled()
+
+      // Should abort at 5000ms
+      jest.advanceTimersByTime(1)
+      expect(abortSpy).toHaveBeenCalled()
+
+      abortSpy.mockRestore()
+    })
+
+    it('should clear timeout when fetch succeeds', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+      const mockResponse = new Response('ok', { status: 200 })
+      mockFetch.mockResolvedValueOnce(mockResponse)
+
+      const promise = fetchWithTimeout('https://api.example.com/data')
+      jest.runAllTimers()
+      await promise
+
+      expect(clearTimeoutSpy).toHaveBeenCalled()
+      clearTimeoutSpy.mockRestore()
+    })
+
+    it('should clear timeout when fetch fails', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const promise = fetchWithTimeout('https://api.example.com/data')
+      jest.runAllTimers()
+
+      await expect(promise).rejects.toThrow('Network error')
+      expect(clearTimeoutSpy).toHaveBeenCalled()
+      clearTimeoutSpy.mockRestore()
+    })
+
+    it('should pass through all fetch options except signal', async () => {
+      const mockResponse = new Response('ok', { status: 200 })
+      mockFetch.mockResolvedValueOnce(mockResponse)
+
+      const promise = fetchWithTimeout('https://api.example.com/data', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Api-Key': 'secret',
+        },
+        body: JSON.stringify({ key: 'value' }),
+        credentials: 'include',
+        timeoutMs: 15000,
+      })
+
+      jest.runAllTimers()
+      await promise
+
+      expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Api-Key': 'secret',
+        },
+        body: JSON.stringify({ key: 'value' }),
+        credentials: 'include',
+        signal: expect.any(AbortSignal),
+      })
+    })
+
+    it('should work with empty options', async () => {
+      const mockResponse = new Response('ok', { status: 200 })
+      mockFetch.mockResolvedValueOnce(mockResponse)
+
+      const promise = fetchWithTimeout('https://api.example.com/data')
+      jest.runAllTimers()
+      const response = await promise
+
+      expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+        signal: expect.any(AbortSignal),
+      })
+      expect(response).toBe(mockResponse)
+    })
+
+    it('should throw AbortError when timeout is reached', async () => {
+      const abortError = new Error('Aborted')
+      abortError.name = 'AbortError'
+      mockFetch.mockImplementation((_url, options) => {
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener('abort', () => {
+            reject(abortError)
+          })
+        })
+      })
+
+      const promise = fetchWithTimeout('https://api.example.com/data', { timeoutMs: 1000 })
+
+      jest.advanceTimersByTime(1000)
+
+      await expect(promise).rejects.toThrow('Aborted')
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    })
+  })
+
+  describe('isTimeoutError', () => {
+    it('should return true for AbortError', () => {
+      const error = new Error('Aborted')
+      error.name = 'AbortError'
+      expect(isTimeoutError(error)).toBe(true)
+    })
+
+    it('should return false for other errors', () => {
+      const error = new Error('Network error')
+      expect(isTimeoutError(error)).toBe(false)
+    })
+
+    it('should return false for TypeError', () => {
+      const error = new TypeError('Invalid URL')
+      expect(isTimeoutError(error)).toBe(false)
+    })
+
+    it('should return false for non-Error objects', () => {
+      expect(isTimeoutError('AbortError')).toBe(false)
+      expect(isTimeoutError({ name: 'AbortError' })).toBe(false)
+      expect(isTimeoutError(null)).toBe(false)
+      expect(isTimeoutError(undefined)).toBe(false)
+    })
+  })
+})

--- a/lib/utils/fetch-with-timeout.ts
+++ b/lib/utils/fetch-with-timeout.ts
@@ -1,0 +1,58 @@
+/**
+ * Fetch utility with timeout support
+ *
+ * Provides a wrapper around the native fetch API that includes automatic
+ * timeout handling via AbortController. This eliminates duplicated
+ * timeout/abort logic across connection files.
+ */
+
+export interface FetchWithTimeoutOptions extends Omit<RequestInit, 'signal'> {
+  /** Timeout in milliseconds (default: 10000ms / 10 seconds) */
+  timeoutMs?: number
+}
+
+/**
+ * Fetch with automatic timeout handling
+ *
+ * @param url - The URL to fetch
+ * @param options - Fetch options including optional timeout
+ * @returns The fetch Response object
+ * @throws Error with name "AbortError" if timeout is exceeded
+ *
+ * @example
+ * ```ts
+ * const response = await fetchWithTimeout('https://api.example.com/data', {
+ *   method: 'GET',
+ *   headers: { 'Accept': 'application/json' },
+ *   timeoutMs: 5000, // 5 second timeout
+ * })
+ * ```
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: FetchWithTimeoutOptions = {}
+): Promise<Response> {
+  const { timeoutMs = 10000, ...fetchOptions } = options
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    return await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Check if an error is a timeout abort error
+ *
+ * @param error - The error to check
+ * @returns true if the error is an AbortError (timeout)
+ */
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError"
+}


### PR DESCRIPTION
## Summary
- Create `lib/utils/fetch-with-timeout.ts` utility with `fetchWithTimeout` and `isTimeoutError` helpers
- Add comprehensive unit tests for the new utility (12 tests)
- Refactor all connection files to use the new utility, eliminating duplicated AbortController/setTimeout/clearTimeout pattern
- Reduces boilerplate by ~89 lines across 10 files

## Files Changed

| File | Functions Updated |
|------|-------------------|
| `lib/connections/plex-connection.ts` | `testPlexConnection`, `getPlexServerIdentity` |
| `lib/connections/plex-users.ts` | `getPlexUserInfo`, `getPlexUsers`, `getAllPlexServerUsers` |
| `lib/connections/plex-sessions.ts` | `getPlexSessions`, `getPlexLibrarySections`, `getPlexRecentlyAdded`, `getPlexOnDeck` |
| `lib/connections/plex-search.ts` | `searchPlexMedia` |
| `lib/connections/plex-marking.ts` | `markPlexItemWatched`, `markPlexItemUnwatched` |
| `lib/connections/sonarr.ts` | `testSonarrConnection` |
| `lib/connections/radarr.ts` | `testRadarrConnection` |
| `lib/connections/tautulli.ts` | `testTautulliConnection` |
| `lib/connections/overseerr.ts` | `testOverseerrConnection` |
| `lib/wrapped/api-calls.ts` | `callOpenAI` (uses configurable 5-minute timeout) |

## Test plan
- [x] Unit tests for `fetchWithTimeout` utility pass (12 tests)
- [x] Lint passes
- [x] Build passes
- [x] All existing tests pass (2 pre-existing failures in `CandidateList.test.tsx` unrelated to this change)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)